### PR TITLE
Sugestão para model Month

### DIFF
--- a/src/Xalendar.Api.Tests/Models/DayTests.cs
+++ b/src/Xalendar.Api.Tests/Models/DayTests.cs
@@ -81,8 +81,9 @@ namespace Xalendar.Api.Tests.Models
             var dayTwo = new Day(DateTime.Now);
 
             var comparison = dayOne.Equals(dayTwo);
-
+            var hashCodeComparision = dayOne.GetHashCode().Equals(dayTwo.GetHashCode());
             Assert.IsTrue(comparison);
+            Assert.IsTrue(hashCodeComparision);
         }
         
         [Test]

--- a/src/Xalendar.Api.Tests/Models/MonthTests.cs
+++ b/src/Xalendar.Api.Tests/Models/MonthTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using NUnit.Framework;
+using Xalendar.Api.Extensions;
 using Xalendar.Api.Models;
 
 namespace Xalendar.Api.Tests.Models
@@ -14,7 +15,7 @@ namespace Xalendar.Api.Tests.Models
             var dateTime = new DateTime(2020, 6, 4);
             var month = new Month(dateTime);
 
-            var result = month.GetDaysOfMonth();
+            var result = month.Days;
 
             Assert.AreEqual(30, result.Count);
         }
@@ -25,7 +26,7 @@ namespace Xalendar.Api.Tests.Models
             var dateTime = new DateTime(2020, 2, 1);
             var month = new Month(dateTime);
 
-            var result = month.GetDaysOfMonth();
+            var result = month.Days;
 
             Assert.AreEqual(29, result.Count);
         }

--- a/src/Xalendar.Api/Extensions/MonthExtension.cs
+++ b/src/Xalendar.Api/Extensions/MonthExtension.cs
@@ -1,0 +1,38 @@
+using System.Linq;
+using Xalendar.Api.Models;
+
+namespace Xalendar.Api.Extensions
+{
+    public static class MonthExtension
+    {
+        public static void SelectDay(this Month month, Day selectedDay)
+        {
+            UnSelectCurrentDay(month);
+            SelectNewDay(selectedDay, month);
+        }
+
+        private static void SelectNewDay(Day selectedDay, Month month)
+        {
+            var newSelectedDay = month.Days.FirstOrDefault(day => day.DateTime.Equals(selectedDay.DateTime));
+
+            if (newSelectedDay is null)
+                return;
+
+            newSelectedDay.IsSelected = true;
+        }
+
+        private static void UnSelectCurrentDay(Month month)
+        {
+            var selectedDay = month.GetSelectedDay();
+            if (selectedDay is null)
+                return;
+
+            selectedDay.IsSelected = false;
+        }
+        
+        public static Day GetSelectedDay(this Month month)
+        {
+            return month.Days.FirstOrDefault(day => day.IsSelected);
+        }
+    }
+}

--- a/src/Xalendar.Api/Extensions/MonthExtension.cs
+++ b/src/Xalendar.Api/Extensions/MonthExtension.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using Xalendar.Api.Models;
 
@@ -33,6 +35,15 @@ namespace Xalendar.Api.Extensions
         public static Day GetSelectedDay(this Month month)
         {
             return month.Days.FirstOrDefault(day => day.IsSelected);
+        }
+        
+        public static List<Day> GenerateDaysOfMonth(DateTime dateTime)
+        {
+            return Enumerable
+                .Range(1, DateTime.DaysInMonth(dateTime.Year, dateTime.Month))
+                .Select(dayValue => new DateTime(dateTime.Year, dateTime.Month, dayValue))
+                .Select(dateTime => new Day(dateTime))
+                .ToList();
         }
     }
 }

--- a/src/Xalendar.Api/Models/Day.cs
+++ b/src/Xalendar.Api/Models/Day.cs
@@ -4,16 +4,16 @@ namespace Xalendar.Api.Models
 {
     public class Day
     {
-        private readonly DateTime _dateTime;
+        public DateTime DateTime { get; }
 
         public Day(DateTime dateTime, bool isSelected = false)
         {
-            _dateTime = dateTime;
+            DateTime = dateTime;
             _isSelected = isSelected;
         }
 
-        public bool IsToday => DateTime.Now.Day == _dateTime.Day;
-        
+        public bool IsToday => DateTime.Now.Day == DateTime.Day;
+
         private bool _isSelected;
 
         public bool IsSelected
@@ -22,14 +22,15 @@ namespace Xalendar.Api.Models
             set => _isSelected = value;
         }
 
-        public DateTime DateTime => _dateTime;
-
         public override bool Equals(object obj)
         {
             if (obj is Day dayToCompare)
-                return dayToCompare.DateTime.Date.Ticks == _dateTime.Date.Ticks;
-            
+                return dayToCompare.DateTime.Date.Ticks == DateTime.Date.Ticks;
+
             return false;
         }
+
+        public override int GetHashCode() =>
+            (DateTime.Date.Ticks).GetHashCode();
     }
 }

--- a/src/Xalendar.Api/Models/Month.cs
+++ b/src/Xalendar.Api/Models/Month.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
+using static Xalendar.Api.Extensions.MonthExtension;
 
 namespace Xalendar.Api.Models
 {
-    public class Month
+    public struct Month : IEquatable<Month>
     {
         public DateTime MonthDateTime {get;}
         public IReadOnlyList<Day> Days {get;}
@@ -12,16 +12,21 @@ namespace Xalendar.Api.Models
         public Month(DateTime dateTime)
         {
             MonthDateTime = dateTime;
-            Days = GenerateDaysOfMonth();
+            Days = GenerateDaysOfMonth(dateTime);
         }
 
-        private List<Day> GenerateDaysOfMonth()
-        {
-            return Enumerable
-                .Range(1, DateTime.DaysInMonth(MonthDateTime.Year, MonthDateTime.Month))
-                .Select(dayValue => new DateTime(MonthDateTime.Year, MonthDateTime.Month, dayValue))
-                .Select(dateTime => new Day(dateTime))
-                .ToList();
-        }
+        public bool Equals(Month other) =>
+            (MonthDateTime, Days) == (other.MonthDateTime, other.Days);
+        
+        public static bool  operator ==(Month left, Month right) =>
+            left.Equals(right);
+        public static bool  operator !=(Month left, Month right) =>
+            !left.Equals(right);
+
+        public override bool Equals(object obj) =>
+            (obj is Month month) && (this.Equals(month));
+        
+        public override int GetHashCode() =>
+            (MonthDateTime, Days).GetHashCode();
     }
 }

--- a/src/Xalendar.Api/Models/Month.cs
+++ b/src/Xalendar.Api/Models/Month.cs
@@ -6,59 +6,22 @@ namespace Xalendar.Api.Models
 {
     public class Month
     {
-        private readonly DateTime _dateTime;
-        private readonly IReadOnlyList<Day> _days;
+        public DateTime MonthDateTime {get;}
+        public IReadOnlyList<Day> Days {get;}
 
         public Month(DateTime dateTime)
         {
-            _dateTime = dateTime;
-            _days = GenerateDaysOfMonth();
+            MonthDateTime = dateTime;
+            Days = GenerateDaysOfMonth();
         }
 
         private List<Day> GenerateDaysOfMonth()
         {
             return Enumerable
-                .Range(1, DateTime.DaysInMonth(_dateTime.Year, _dateTime.Month))
-                .Select(dayValue => new DateTime(_dateTime.Year, _dateTime.Month, dayValue))
+                .Range(1, DateTime.DaysInMonth(MonthDateTime.Year, MonthDateTime.Month))
+                .Select(dayValue => new DateTime(MonthDateTime.Year, MonthDateTime.Month, dayValue))
                 .Select(dateTime => new Day(dateTime))
                 .ToList();
-        }
-
-        public IReadOnlyList<Day> GetDaysOfMonth()
-        {
-            return _days;
-        }
-
-        public void SelectDay(Day selectedDay)
-        {
-            UnSelectCurrentDay();
-            SelectNewDay(selectedDay);
-        }
-
-        private void UnSelectCurrentDay()
-        {
-            var selectedDay = GetSelectedDay();
-            if (selectedDay is null)
-                return;
-            
-            selectedDay.IsSelected = false;
-        }
-        
-        private void SelectNewDay(Day selectedDay)
-        {
-            var newSelectedDay = GetDaysOfMonth()
-                .FirstOrDefault(day => day.DateTime.Equals(selectedDay.DateTime));
-
-            if (newSelectedDay is null)
-                return;
-            
-            newSelectedDay.IsSelected = true;
-        }
-
-        public Day GetSelectedDay()
-        {
-            return GetDaysOfMonth()
-                .FirstOrDefault(day => day.IsSelected);
         }
     }
 }


### PR DESCRIPTION
@ionixjunior, esse PR contempla as alterações do #9 e muda a model `Month` para `struct`. 
Eu sei que você passou por maus bocados na última live por conta da `struct`, então adiciono algumas considerações aqui:

Isso fazer sentido se a model `Month` for imutável, analisando por alto, eu acredito que ela seja, pois um mês não vai mudar, depois de criado, o que vai mudar são os dias (se está selecionado ou não e talvez os eventos daquele dia), se isso for verdade, faz sentido a model `Day` continuar como `class`, para facilitar as mutações e a model `Month` ser uma `struct`. 

Mas se por algum motivo, você ver que `Month` pode ser mutável, por favor desconsidere esse PR.