### PR TITLE
Implementado Days no HashCode de Month.

### DIFF
--- a/src/Xalendar.Api.Tests/Models/MonthContainerTests.cs
+++ b/src/Xalendar.Api.Tests/Models/MonthContainerTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
@@ -14,9 +14,9 @@ namespace Xalendar.Api.Tests.Models
         public void MonthContainerShouldContainsDaysOfMonth()
         {
             var dateTime = DateTime.Now;
-            
+
             var monthContainer = new MonthContainer(dateTime);
-            
+
             Assert.IsNotEmpty(monthContainer.Days);
         }
 
@@ -28,7 +28,7 @@ namespace Xalendar.Api.Tests.Models
             var selectedDay = new Day(dateTime, true);
 
             monthContainer.SelectDay(selectedDay);
-            
+
             Assert.AreEqual(selectedDay, monthContainer.GetSelectedDay());
         }
 
@@ -37,10 +37,10 @@ namespace Xalendar.Api.Tests.Models
         {
             var dateTime = new DateTime(2020, 7, 9);
             var monthContainer = new MonthContainer(dateTime);
-            
+
             Assert.IsFalse(monthContainer._month.Days.Any(day => day.HasEvents));
         }
-        
+
         [Test]
         public void MonthContainerShouldContainsEvents()
         {
@@ -50,9 +50,9 @@ namespace Xalendar.Api.Tests.Models
             {
                 new Event(1, "Name event", dateTime, dateTime, false)
             };
-            
+
             monthContainer.AddEvents(events);
-            
+
             Assert.IsTrue(monthContainer._month.Days.Any(day => day.HasEvents));
         }
 
@@ -63,8 +63,8 @@ namespace Xalendar.Api.Tests.Models
             var monthContainer = new MonthContainer(dateTime);
 
             var result = monthContainer.GetName();
-            
-            Assert.AreEqual("July", result);
+            var dateTimeName = dateTime.ToString("MMMM");
+            Assert.AreEqual(dateTimeName, result);
         }
 
         [Test]
@@ -74,8 +74,9 @@ namespace Xalendar.Api.Tests.Models
             var monthContainer = new MonthContainer(dateTime);
 
             monthContainer.Next();
-            
-            Assert.AreEqual("January", monthContainer.GetName());
+
+            var dateTimeName = monthContainer._month.MonthDateTime.ToString("MMMM");
+            Assert.AreEqual(dateTimeName, monthContainer.GetName());
         }
 
         [Test]
@@ -85,8 +86,9 @@ namespace Xalendar.Api.Tests.Models
             var monthContainer = new MonthContainer(dateTime);
 
             monthContainer.Previous();
-            
-            Assert.AreEqual("December", monthContainer.GetName());
+
+            var dateTimeName = monthContainer._month.MonthDateTime.ToString("MMMM");
+            Assert.AreEqual(dateTimeName, monthContainer.GetName());
         }
     }
 }

--- a/src/Xalendar.Api.Tests/Models/MonthTests.cs
+++ b/src/Xalendar.Api.Tests/Models/MonthTests.cs
@@ -39,7 +39,7 @@ namespace Xalendar.Api.Tests.Models
             var month = new Month(dateTime);
 
             var selectedDay = month.GetSelectedDay();
-            
+
             Assert.IsNull(selectedDay);
         }
 
@@ -53,7 +53,7 @@ namespace Xalendar.Api.Tests.Models
             month.SelectDay(day);
 
             var selectedDay = month.GetSelectedDay();
-            
+
             Assert.AreEqual(day, selectedDay);
         }
 
@@ -69,7 +69,7 @@ namespace Xalendar.Api.Tests.Models
             month.SelectDay(newDaySelected);
 
             var selectedDay = month.GetSelectedDay();
-            
+
             Assert.AreEqual(newDaySelected, selectedDay);
         }
 
@@ -83,7 +83,7 @@ namespace Xalendar.Api.Tests.Models
             month.SelectDay(day);
 
             var selectedDay = month.GetSelectedDay();
-            
+
             Assert.IsNull(selectedDay);
         }
 
@@ -94,10 +94,12 @@ namespace Xalendar.Api.Tests.Models
             var month2 = new Month(new DateTime(2020, 1, 10));
 
             var result = month1.Equals(month2);
-            
+            var hashCodeResult = month1.GetHashCode() == month2.GetHashCode();
+
             Assert.IsTrue(result);
+            Assert.IsTrue(hashCodeResult);
         }
-        
+
         [Test]
         public void MonthsNotShouldBeEquals()
         {
@@ -105,8 +107,10 @@ namespace Xalendar.Api.Tests.Models
             var month2 = new Month(new DateTime(2020, 2, 1));
 
             var result = month1.Equals(month2);
-            
+            var hashCodeResult = month1.GetHashCode() == month2.GetHashCode();
+
             Assert.IsFalse(result);
+            Assert.IsFalse(hashCodeResult);
         }
 
         [Test]
@@ -116,10 +120,10 @@ namespace Xalendar.Api.Tests.Models
             object object2 = new Month(new DateTime(2020, 1, 10));
 
             var result = object1.Equals(object2);
-            
+
             Assert.IsTrue(result);
         }
-        
+
         [Test]
         public void ObjectsNotShouldBeEquals()
         {
@@ -127,7 +131,7 @@ namespace Xalendar.Api.Tests.Models
             object object2 = new Month(new DateTime(2020, 2, 1));
 
             var result = object1.Equals(object2);
-            
+
             Assert.IsFalse(result);
         }
 
@@ -138,10 +142,10 @@ namespace Xalendar.Api.Tests.Models
             var month2 = new Month(new DateTime(2020, 1, 10));
 
             var result = month1 == month2;
-            
+
             Assert.IsTrue(result);
         }
-        
+
         [Test]
         public void MonthNotEqualsOperatorNotShouldBeEquals()
         {
@@ -149,7 +153,7 @@ namespace Xalendar.Api.Tests.Models
             var month2 = new Month(new DateTime(2020, 2, 1));
 
             var result = month1 != month2;
-            
+
             Assert.IsTrue(result);
         }
 
@@ -162,10 +166,10 @@ namespace Xalendar.Api.Tests.Models
             var hashCodeMonth2 = month2.GetHashCode();
 
             var result = hashCodeMonth1 == hashCodeMonth2;
-            
+
             Assert.IsTrue(result);
         }
-        
+
         [Test]
         public void HashCodeNotShouldBeEquals()
         {
@@ -175,7 +179,7 @@ namespace Xalendar.Api.Tests.Models
             var hashCodeMonth2 = month2.GetHashCode();
 
             var result = hashCodeMonth1 == hashCodeMonth2;
-            
+
             Assert.IsFalse(result);
         }
 
@@ -185,7 +189,7 @@ namespace Xalendar.Api.Tests.Models
             var month = new Month(new DateTime(2020, 1, 1));
 
             var eventsOfMonth = month.Days.Where(day => day.Events.Any());
-            
+
             Assert.IsEmpty(eventsOfMonth);
         }
 
@@ -201,7 +205,7 @@ namespace Xalendar.Api.Tests.Models
             month.AddEvents(events);
 
             var eventsOfMonth = month.Days.Where(day => day.Events.Any());
-            
+
             Assert.IsNotEmpty(eventsOfMonth);
             Assert.AreEqual(1, eventsOfMonth.Count());
         }
@@ -219,7 +223,7 @@ namespace Xalendar.Api.Tests.Models
             month.AddEvents(events);
 
             var eventsOfMonth = month.Days.Where(day => day.Events.Any());
-            
+
             Assert.IsNotEmpty(eventsOfMonth);
             Assert.AreEqual(1, eventsOfMonth.Count());
         }

--- a/src/Xalendar.Api/Models/Month.cs
+++ b/src/Xalendar.Api/Models/Month.cs
@@ -5,7 +5,7 @@ using static Xalendar.Api.Extensions.MonthExtension;
 
 namespace Xalendar.Api.Models
 {
-    public struct Month : IEquatable<Month>
+    public readonly struct Month : IEquatable<Month>
     {
         public DateTime MonthDateTime { get; }
         public IReadOnlyList<Day> Days { get; }

--- a/src/Xalendar.Api/Models/Month.cs
+++ b/src/Xalendar.Api/Models/Month.cs
@@ -7,8 +7,8 @@ namespace Xalendar.Api.Models
 {
     public struct Month : IEquatable<Month>
     {
-        public DateTime MonthDateTime {get;}
-        public IReadOnlyList<Day> Days {get;}
+        public DateTime MonthDateTime { get; }
+        public IReadOnlyList<Day> Days { get; }
 
         public Month(DateTime dateTime)
         {
@@ -21,13 +21,13 @@ namespace Xalendar.Api.Models
             var yearValue = MonthDateTime.Year == other.MonthDateTime.Year;
             var monthValue = MonthDateTime.Month == other.MonthDateTime.Month;
             var days = Days.SequenceEqual(other.Days);
-            
+
             return yearValue && monthValue && days;
         }
-        
-        public static bool  operator ==(Month left, Month right) =>
+
+        public static bool operator ==(Month left, Month right) =>
             left.Equals(right);
-        public static bool  operator !=(Month left, Month right) =>
+        public static bool operator !=(Month left, Month right) =>
             !left.Equals(right);
 
         public override bool Equals(object obj) =>
@@ -37,9 +37,25 @@ namespace Xalendar.Api.Models
         {
             var yearValue = MonthDateTime.Year;
             var monthValue = MonthDateTime.Month;
-            
-            // TODO Comparison should be contains the days like as Equals comparison
-            return (yearValue, monthValue).GetHashCode();
+            var dayHash = GetListHasCode(Days);
+
+            return (yearValue, monthValue, dayHash).GetHashCode();
+
+            static int GetListHasCode(IReadOnlyList<Day> days)
+            {
+                var size = days.Count;
+                unchecked
+                {
+                    var hash = 31;
+                    for (var i = 0; i < size; i++)
+                    {
+                        var day = days[i];
+                        hash = 17 * hash + day.GetHashCode();
+                    }
+
+                    return hash;
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
E ai @ionixjunior , tranquilo? Olha eu ai de novo...

Dessa vez eu implementei o cálculo para o HashCode da coleção Days, dentro da struct Month. Para mais informações da abordagem utilizada você pode consultar [este artigo.](https://medium.com/@pedro_jesus/entendendo-o-hashcode-8c59fbf0c1db).

Utilizei o `loop for` por ser mais performático, como você pode ver nos resultados abaixo, esse modelo é até 2 vezes mais rápido do que o `loop foreach` e não tem alocações.

|             Method |     Mean |   Error |  StdDev | Ratio |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------- |---------:|--------:|--------:|------:|-------:|------:|------:|----------:|
| GetHashCodeForeach | 446.9 ns | 4.76 ns | 4.45 ns |  1.00 | 0.0124 |     - |     - |      40 B |
|     GetHashCodeFor | 206.2 ns | 2.02 ns | 1.89 ns |  0.46 |      - |     - |     - |         - |



Também "corrigi" os testes relacionados aos nomes do meses, dentro de `MonthContainerTest`, como eles estavam _hard coded_ acabaram falhando no meu PC, que tem como idioma padrão o pt-BR. A imagem abaixo mostra um dos erros.
![image](https://user-images.githubusercontent.com/20712372/87616282-1e870200-c6eb-11ea-99d9-ed3d0ed4c4d0.png)

Infelizmente não poderei acompanhar o code review pela sua live amanhã, pois conflita com o Xamarin Assemble, evento que irei palestrar no mesmo horário da sua live. Mas qualquer coisa pode me pingar nas redes sociais, que assim que possível irei responder.

Abraços.