### PR TITLE
Adicionar elementos básicos no CalendarView

### DIFF
--- a/src/Xalendar.Api.Tests/Models/MonthContainerTests.cs
+++ b/src/Xalendar.Api.Tests/Models/MonthContainerTests.cs
@@ -11,14 +11,21 @@ namespace Xalendar.Api.Tests.Models
     public class MonthContainerTests
     {
         [Test]
-        public void MonthContainerShouldContainsDaysOfMonth()
+        [TestCaseSource(nameof(MonthsValuesTests))]
+        public void MonthContainerShouldContainsDaysOfMonthAndPreviousAndNext(DateTime dateTime, int totalOfDays)
         {
-            var dateTime = DateTime.Now;
-
             var monthContainer = new MonthContainer(dateTime);
 
             Assert.IsNotEmpty(monthContainer.Days);
+            Assert.AreEqual(totalOfDays, monthContainer.Days.Count);
         }
+
+        private static object[] MonthsValuesTests =
+        {
+            new object[] { new DateTime(2020, 7, 23), 35 },
+            new object[] { new DateTime(2015, 2, 10), 28 },
+            new object[] { new DateTime(2020, 8, 1), 42 }
+        };
 
         [Test]
         public void MonthContainerCanSelectDay()

--- a/src/Xalendar.Api.Tests/Models/MonthContainerTests.cs
+++ b/src/Xalendar.Api.Tests/Models/MonthContainerTests.cs
@@ -114,7 +114,7 @@ namespace Xalendar.Api.Tests.Models
         {
             new object[] { "pt-BR", "DOM" },
             new object[] { "en-US", "SUN" },
-            new object[] { "fr-FR", "DIM." }
+            new object[] { "fr-FR", "DIM" }
         };
     }
 }

--- a/src/Xalendar.Api.Tests/Models/MonthContainerTests.cs
+++ b/src/Xalendar.Api.Tests/Models/MonthContainerTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using NUnit.Framework;
 using Xalendar.Api.Extensions;
@@ -97,5 +98,23 @@ namespace Xalendar.Api.Tests.Models
             var dateTimeName = monthContainer._month.MonthDateTime.ToString("MMMM");
             Assert.AreEqual(dateTimeName, monthContainer.GetName());
         }
+
+        [Test]
+        [TestCaseSource(nameof(ValuesForDaysOfWeekTests))]
+        public void MonthContainerShouldContainsTheDaysOfWeekInSpecificLanguages(string language, string dayOfWeekName)
+        {
+            CultureInfo.CurrentCulture = new CultureInfo(language);
+            var dateTime = DateTime.Today;
+            var monthContainer = new MonthContainer(dateTime);
+            
+            Assert.AreEqual(dayOfWeekName, monthContainer.DaysOfWeek.First());
+        }
+        
+        private static object[] ValuesForDaysOfWeekTests =
+        {
+            new object[] { "pt-BR", "DOM" },
+            new object[] { "en-US", "SUN" },
+            new object[] { "fr-FR", "DIM." }
+        };
     }
 }

--- a/src/Xalendar.Api/Extensions/MonthContainerExtension.cs
+++ b/src/Xalendar.Api/Extensions/MonthContainerExtension.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using Xalendar.Api.Models;
 
 namespace Xalendar.Api.Extensions
@@ -20,6 +21,24 @@ namespace Xalendar.Api.Extensions
         {
             var previousDateTime = monthContainer._month.MonthDateTime.AddMonths(-1);
             monthContainer._month = new Month(previousDateTime);
+        }
+        
+        internal static void GetDaysToDiscardAtStartOfMonth(this MonthContainer monthContainer, List<Day?> daysOfContainer)
+        {
+            var firstDay = monthContainer._month.Days.First();
+            var numberOfDaysToDiscard = (int) firstDay!.DateTime.DayOfWeek;
+            
+            for (var index = 0; index < numberOfDaysToDiscard; index++)
+                daysOfContainer.Add(default(Day));
+        }
+        
+        internal static void GetDaysToDiscardAtEndOfMonth(this MonthContainer monthContainer, List<Day?> daysOfContainer)
+        {
+            var lastDay = monthContainer._month.Days.Last();
+            var numberOfDaysToDiscard = 6 - (int) lastDay.DateTime.DayOfWeek;
+            
+            for (var index = 0; index < numberOfDaysToDiscard; index++)
+                daysOfContainer.Add(default(Day));
         }
     }
 }

--- a/src/Xalendar.Api/Models/MonthContainer.cs
+++ b/src/Xalendar.Api/Models/MonthContainer.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Globalization;
 using Xalendar.Api.Extensions;
 
 namespace Xalendar.Api.Models
@@ -11,6 +12,7 @@ namespace Xalendar.Api.Models
         public Month _month;
         
         public IReadOnlyList<Day?> Days { get; }
+        public IReadOnlyList<string> DaysOfWeek { get; }
         
         public MonthContainer(DateTime dateTime)
         {
@@ -21,6 +23,18 @@ namespace Xalendar.Api.Models
             daysOfContainer.AddRange(_month.Days);
             this.GetDaysToDiscardAtEndOfMonth(daysOfContainer);
             Days = daysOfContainer;
+
+            var cultureInfo = CultureInfo.CurrentCulture;
+            DaysOfWeek = new List<string>
+            {
+                cultureInfo.DateTimeFormat.GetAbbreviatedDayName(DayOfWeek.Sunday).ToUpper(),
+                cultureInfo.DateTimeFormat.GetAbbreviatedDayName(DayOfWeek.Monday).ToUpper(),
+                cultureInfo.DateTimeFormat.GetAbbreviatedDayName(DayOfWeek.Tuesday).ToUpper(),
+                cultureInfo.DateTimeFormat.GetAbbreviatedDayName(DayOfWeek.Wednesday).ToUpper(),
+                cultureInfo.DateTimeFormat.GetAbbreviatedDayName(DayOfWeek.Thursday).ToUpper(),
+                cultureInfo.DateTimeFormat.GetAbbreviatedDayName(DayOfWeek.Friday).ToUpper(),
+                cultureInfo.DateTimeFormat.GetAbbreviatedDayName(DayOfWeek.Saturday).ToUpper()
+            };
         }
     }
 }

--- a/src/Xalendar.Api/Models/MonthContainer.cs
+++ b/src/Xalendar.Api/Models/MonthContainer.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
+using Xalendar.Api.Extensions;
 
 namespace Xalendar.Api.Models
 {
@@ -17,28 +17,10 @@ namespace Xalendar.Api.Models
             _month = new Month(dateTime);
             
             var daysOfContainer = new List<Day?>();
-            GetDaysToDiscardAtStartOfMonth(daysOfContainer);
+            this.GetDaysToDiscardAtStartOfMonth(daysOfContainer);
             daysOfContainer.AddRange(_month.Days);
-            GetDaysToDiscardAtEndOfMonth(daysOfContainer);
+            this.GetDaysToDiscardAtEndOfMonth(daysOfContainer);
             Days = daysOfContainer;
-        }
-
-        private void GetDaysToDiscardAtStartOfMonth(List<Day?> daysOfContainer)
-        {
-            var firstDay = _month.Days.First();
-            var numberOfDaysToDiscard = (int) firstDay.DateTime.DayOfWeek;
-            
-            for (var index = 0; index < numberOfDaysToDiscard; index++)
-                daysOfContainer.Add(default(Day));
-        }
-
-        private void GetDaysToDiscardAtEndOfMonth(List<Day?> daysOfContainer)
-        {
-            var lastDay = _month.Days.Last();
-            var numberOfDaysToDiscard = 6 - (int) lastDay.DateTime.DayOfWeek;
-            
-            for (var index = 0; index < numberOfDaysToDiscard; index++)
-                daysOfContainer.Add(default(Day));
         }
     }
 }

--- a/src/Xalendar.Api/Models/MonthContainer.cs
+++ b/src/Xalendar.Api/Models/MonthContainer.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Linq;
 
 namespace Xalendar.Api.Models
 {
@@ -9,12 +10,35 @@ namespace Xalendar.Api.Models
         [EditorBrowsable(EditorBrowsableState.Never)]
         public Month _month;
         
-        public IReadOnlyList<Day> Days { get; }
+        public IReadOnlyList<Day?> Days { get; }
         
         public MonthContainer(DateTime dateTime)
         {
             _month = new Month(dateTime);
-            Days = _month.Days;
+            
+            var daysOfContainer = new List<Day?>();
+            GetDaysToDiscardAtStartOfMonth(daysOfContainer);
+            daysOfContainer.AddRange(_month.Days);
+            GetDaysToDiscardAtEndOfMonth(daysOfContainer);
+            Days = daysOfContainer;
+        }
+
+        private void GetDaysToDiscardAtStartOfMonth(List<Day?> daysOfContainer)
+        {
+            var firstDay = _month.Days.First();
+            var numberOfDaysToDiscard = (int) firstDay.DateTime.DayOfWeek;
+            
+            for (var index = 0; index < numberOfDaysToDiscard; index++)
+                daysOfContainer.Add(default(Day));
+        }
+
+        private void GetDaysToDiscardAtEndOfMonth(List<Day?> daysOfContainer)
+        {
+            var lastDay = _month.Days.Last();
+            var numberOfDaysToDiscard = 6 - (int) lastDay.DateTime.DayOfWeek;
+            
+            for (var index = 0; index < numberOfDaysToDiscard; index++)
+                daysOfContainer.Add(default(Day));
         }
     }
 }

--- a/src/Xalendar.Api/Models/MonthContainer.cs
+++ b/src/Xalendar.Api/Models/MonthContainer.cs
@@ -27,13 +27,13 @@ namespace Xalendar.Api.Models
             var cultureInfo = CultureInfo.CurrentCulture;
             DaysOfWeek = new List<string>
             {
-                cultureInfo.DateTimeFormat.GetAbbreviatedDayName(DayOfWeek.Sunday).ToUpper(),
-                cultureInfo.DateTimeFormat.GetAbbreviatedDayName(DayOfWeek.Monday).ToUpper(),
-                cultureInfo.DateTimeFormat.GetAbbreviatedDayName(DayOfWeek.Tuesday).ToUpper(),
-                cultureInfo.DateTimeFormat.GetAbbreviatedDayName(DayOfWeek.Wednesday).ToUpper(),
-                cultureInfo.DateTimeFormat.GetAbbreviatedDayName(DayOfWeek.Thursday).ToUpper(),
-                cultureInfo.DateTimeFormat.GetAbbreviatedDayName(DayOfWeek.Friday).ToUpper(),
-                cultureInfo.DateTimeFormat.GetAbbreviatedDayName(DayOfWeek.Saturday).ToUpper()
+                cultureInfo.DateTimeFormat.GetAbbreviatedDayName(DayOfWeek.Sunday).Substring(0, 3).ToUpper(),
+                cultureInfo.DateTimeFormat.GetAbbreviatedDayName(DayOfWeek.Monday).Substring(0, 3).ToUpper(),
+                cultureInfo.DateTimeFormat.GetAbbreviatedDayName(DayOfWeek.Tuesday).Substring(0, 3).ToUpper(),
+                cultureInfo.DateTimeFormat.GetAbbreviatedDayName(DayOfWeek.Wednesday).Substring(0, 3).ToUpper(),
+                cultureInfo.DateTimeFormat.GetAbbreviatedDayName(DayOfWeek.Thursday).Substring(0, 3).ToUpper(),
+                cultureInfo.DateTimeFormat.GetAbbreviatedDayName(DayOfWeek.Friday).Substring(0, 3).ToUpper(),
+                cultureInfo.DateTimeFormat.GetAbbreviatedDayName(DayOfWeek.Saturday).Substring(0, 3).ToUpper()
             };
         }
     }

--- a/src/Xalendar.Api/Models/MonthContainer.cs
+++ b/src/Xalendar.Api/Models/MonthContainer.cs
@@ -25,15 +25,16 @@ namespace Xalendar.Api.Models
             Days = daysOfContainer;
 
             var cultureInfo = CultureInfo.CurrentCulture;
+            var dateTimeFormat = cultureInfo.DateTimeFormat;
             DaysOfWeek = new List<string>
             {
-                cultureInfo.DateTimeFormat.GetAbbreviatedDayName(DayOfWeek.Sunday).Substring(0, 3).ToUpper(),
-                cultureInfo.DateTimeFormat.GetAbbreviatedDayName(DayOfWeek.Monday).Substring(0, 3).ToUpper(),
-                cultureInfo.DateTimeFormat.GetAbbreviatedDayName(DayOfWeek.Tuesday).Substring(0, 3).ToUpper(),
-                cultureInfo.DateTimeFormat.GetAbbreviatedDayName(DayOfWeek.Wednesday).Substring(0, 3).ToUpper(),
-                cultureInfo.DateTimeFormat.GetAbbreviatedDayName(DayOfWeek.Thursday).Substring(0, 3).ToUpper(),
-                cultureInfo.DateTimeFormat.GetAbbreviatedDayName(DayOfWeek.Friday).Substring(0, 3).ToUpper(),
-                cultureInfo.DateTimeFormat.GetAbbreviatedDayName(DayOfWeek.Saturday).Substring(0, 3).ToUpper()
+                dateTimeFormat.GetAbbreviatedDayName(DayOfWeek.Sunday).Substring(0, 3).ToUpper(),
+                dateTimeFormat.GetAbbreviatedDayName(DayOfWeek.Monday).Substring(0, 3).ToUpper(),
+                dateTimeFormat.GetAbbreviatedDayName(DayOfWeek.Tuesday).Substring(0, 3).ToUpper(),
+                dateTimeFormat.GetAbbreviatedDayName(DayOfWeek.Wednesday).Substring(0, 3).ToUpper(),
+                dateTimeFormat.GetAbbreviatedDayName(DayOfWeek.Thursday).Substring(0, 3).ToUpper(),
+                dateTimeFormat.GetAbbreviatedDayName(DayOfWeek.Friday).Substring(0, 3).ToUpper(),
+                dateTimeFormat.GetAbbreviatedDayName(DayOfWeek.Saturday).Substring(0, 3).ToUpper()
             };
         }
     }

--- a/src/Xalendar.View/Controls/CalendarView.xaml
+++ b/src/Xalendar.View/Controls/CalendarView.xaml
@@ -2,11 +2,21 @@
 <ContentView xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="Xalendar.View.Controls.CalendarView">
-    <FlexLayout BackgroundColor="MediumPurple" BindableLayout.ItemsSource="{Binding Days}" Wrap="Wrap">
-        <BindableLayout.ItemTemplate>
-            <DataTemplate>
-                <Label BackgroundColor="Red" FlexLayout.Basis="14.28%" Text="{Binding .}" FontSize="30" />
-            </DataTemplate>
-        </BindableLayout.ItemTemplate>
-    </FlexLayout>
+    <StackLayout Spacing="0">
+        <FlexLayout BackgroundColor="MediumPurple" BindableLayout.ItemsSource="{Binding DaysOfWeek}" Wrap="Wrap">
+            <BindableLayout.ItemTemplate>
+                <DataTemplate>
+                    <Label BackgroundColor="Yellow" FlexLayout.Basis="14.28%" Text="{Binding .}" FontSize="16" />
+                </DataTemplate>
+            </BindableLayout.ItemTemplate>
+        </FlexLayout>
+        
+        <FlexLayout BackgroundColor="MediumPurple" BindableLayout.ItemsSource="{Binding Days}" Wrap="Wrap">
+            <BindableLayout.ItemTemplate>
+                <DataTemplate>
+                    <Label BackgroundColor="Red" FlexLayout.Basis="14.28%" Text="{Binding .}" FontSize="30" />
+                </DataTemplate>
+            </BindableLayout.ItemTemplate>
+        </FlexLayout>
+    </StackLayout>
 </ContentView>

--- a/src/Xalendar.View/Controls/CalendarView.xaml
+++ b/src/Xalendar.View/Controls/CalendarView.xaml
@@ -2,5 +2,11 @@
 <ContentView xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="Xalendar.View.Controls.CalendarView">
-    <Label Text="CalendarView label" FontSize="30"></Label>
+    <FlexLayout BindableLayout.ItemsSource="{Binding Days}" Wrap="Wrap">
+        <BindableLayout.ItemTemplate>
+            <DataTemplate>
+                <Label FlexLayout.Basis="14.28%" Text="{Binding .}" FontSize="30" />
+            </DataTemplate>
+        </BindableLayout.ItemTemplate>
+    </FlexLayout>
 </ContentView>

--- a/src/Xalendar.View/Controls/CalendarView.xaml
+++ b/src/Xalendar.View/Controls/CalendarView.xaml
@@ -2,10 +2,10 @@
 <ContentView xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="Xalendar.View.Controls.CalendarView">
-    <FlexLayout BindableLayout.ItemsSource="{Binding Days}" Wrap="Wrap">
+    <FlexLayout BackgroundColor="MediumPurple" BindableLayout.ItemsSource="{Binding Days}" Wrap="Wrap">
         <BindableLayout.ItemTemplate>
             <DataTemplate>
-                <Label FlexLayout.Basis="14.28%" Text="{Binding .}" FontSize="30" />
+                <Label BackgroundColor="Red" FlexLayout.Basis="14.28%" Text="{Binding .}" FontSize="30" />
             </DataTemplate>
         </BindableLayout.ItemTemplate>
     </FlexLayout>

--- a/src/Xalendar.View/Controls/CalendarView.xaml.cs
+++ b/src/Xalendar.View/Controls/CalendarView.xaml.cs
@@ -1,3 +1,5 @@
+using System;
+using Xalendar.Api.Models;
 using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
@@ -9,6 +11,8 @@ namespace Xalendar.View.Controls
         public CalendarView()
         {
             InitializeComponent();
+
+            BindingContext = new MonthContainer(DateTime.Today);
         }
     }
 }

--- a/src/Xalendar.View/Xalendar.View.csproj
+++ b/src/Xalendar.View/Xalendar.View.csproj
@@ -29,4 +29,8 @@
       <DependentUpon>CalendarView.xaml</DependentUpon>
     </Compile>
   </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Xalendar.Api\Xalendar.Api.csproj" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Essa PR adiciona os elementos básicos do componente, que são: os dias do mês e os dias da semana.

Também foi criada uma solução para preencher os dias que não são relacionados ao mês vigente. Isso foi importante para conseguirmos inserir o primeiro dia do mês no dia da semana correto do calendário.