### PR TITLE
Formatar o XAML e carregar dados em background

### DIFF
--- a/src/Xalendar.Sample/Xalendar.Sample/App.xaml
+++ b/src/Xalendar.Sample/Xalendar.Sample/App.xaml
@@ -1,8 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
-<Application xmlns="http://xamarin.com/schemas/2014/forms"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             x:Class="Xalendar.Sample.App">
-    <Application.Resources>
-
-    </Application.Resources>
+<Application
+    x:Class="Xalendar.Sample.App"
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
+    <Application.Resources />
 </Application>

--- a/src/Xalendar.Sample/Xalendar.Sample/MainPage.xaml
+++ b/src/Xalendar.Sample/Xalendar.Sample/MainPage.xaml
@@ -1,13 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
-<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:local="clr-namespace:Xalendar.Sample"
-             xmlns:xalendar="clr-namespace:Xalendar.View.Controls;assembly=Xalendar.View"
-             Title="CalendarView Sample"
-             x:Class="Xalendar.Sample.MainPage">
-
+<ContentPage
+    Title="CalendarView Sample"
+    x:Class="Xalendar.Sample.MainPage"
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:local="clr-namespace:Xalendar.Sample"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:xalendar="clr-namespace:Xalendar.View.Controls;assembly=Xalendar.View">
     <StackLayout>
         <xalendar:CalendarView />
     </StackLayout>
-
 </ContentPage>

--- a/src/Xalendar.View/Controls/CalendarView.xaml
+++ b/src/Xalendar.View/Controls/CalendarView.xaml
@@ -1,8 +1,9 @@
-<?xml version="1.0" encoding="utf-8"?>
-<ContentView xmlns="http://xamarin.com/schemas/2014/forms"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:converters="clr-namespace:Xalendar.View.Converters;assembly=Xalendar.View"
-             x:Class="Xalendar.View.Controls.CalendarView">
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentView
+    x:Class="Xalendar.View.Controls.CalendarView"
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:converters="clr-namespace:Xalendar.View.Converters;assembly=Xalendar.View"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
     <ContentView.Resources>
         <ResourceDictionary>
             <converters:IsTodayToBackgroundColorConverter x:Key="IsTodayToBackgroundColorConverter" />
@@ -10,68 +11,70 @@
             <FlexBasis x:Key="DayWidth">14.28%</FlexBasis>
         </ResourceDictionary>
     </ContentView.Resources>
-    
+
     <StackLayout Spacing="0">
-        <FlexLayout HeightRequest="56" AlignItems="Center" Padding="10,0">
-            <Button Text="◀" Clicked="OnPreviousMonthClick" />
-            
-            <Label 
-                x:Name="MonthName"
-                FontSize="Title"
+        <FlexLayout
+            AlignItems="Center"
+            HeightRequest="56"
+            Padding="10,0">
+            <Button Clicked="OnPreviousMonthClick" Text="◀" />
+
+            <Label
                 FlexLayout.Grow="1"
-                HorizontalTextAlignment="Center"></Label>
-            
-            <Button Text="▶" Clicked="OnNextMonthClick" />
+                FontSize="Title"
+                HorizontalTextAlignment="Center"
+                x:Name="MonthName" />
+
+            <Button Clicked="OnNextMonthClick" Text="▶" />
         </FlexLayout>
-        
-        <FlexLayout x:Name="CalendarDaysOfWeekContainer" Wrap="Wrap">
+
+        <FlexLayout Wrap="Wrap" x:Name="CalendarDaysOfWeekContainer">
             <BindableLayout.ItemTemplate>
                 <DataTemplate>
-                    <Label 
-                        HeightRequest="56" 
-                        FlexLayout.Basis="{StaticResource DayWidth}" 
-                        HorizontalTextAlignment="Center" 
-                        VerticalTextAlignment="Center" 
-                        Text="{Binding .}" 
-                        FontSize="Body" />
+                    <Label
+                        FlexLayout.Basis="{StaticResource DayWidth}"
+                        FontSize="Body"
+                        HeightRequest="56"
+                        HorizontalTextAlignment="Center"
+                        Text="{Binding .}"
+                        VerticalTextAlignment="Center" />
                 </DataTemplate>
             </BindableLayout.ItemTemplate>
         </FlexLayout>
-        
-        <FlexLayout x:Name="CalendarDaysContainer" Wrap="Wrap">
+
+        <FlexLayout Wrap="Wrap" x:Name="CalendarDaysContainer">
             <BindableLayout.ItemTemplate>
                 <DataTemplate>
-                    <Frame 
-                        CornerRadius="20"
-                        HasShadow="false"
-                        Padding="0"
+                    <Frame
                         BackgroundColor="{Binding ., Converter={StaticResource IsTodayToBackgroundColorConverter}}"
+                        CornerRadius="20"
+                        FlexLayout.Basis="{StaticResource DayWidth}"
+                        HasShadow="false"
                         HeightRequest="56"
-                        FlexLayout.Basis="{StaticResource DayWidth}" >
+                        Padding="0">
                         <Grid RowSpacing="0" VerticalOptions="Center">
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="Auto" />
                                 <RowDefinition Height="14" />
                             </Grid.RowDefinitions>
-                            
-                            <Label 
+
+                            <Label
+                                FontSize="Subtitle"
                                 Grid.Row="0"
-                                HorizontalTextAlignment="Center" 
-                                VerticalTextAlignment="Center" 
-                                Text="{Binding .}" 
-                                FontSize="Subtitle" />
-                            
-                            <BoxView 
-                                IsVisible="{Binding ., Converter={StaticResource HasEventsToVisibilityConverter}}"
-                                Grid.Row="1"
-                                WidthRequest="8"
-                                HeightRequest="8"
+                                HorizontalTextAlignment="Center"
+                                Text="{Binding .}"
+                                VerticalTextAlignment="Center" />
+
+                            <BoxView
+                                BackgroundColor="Black"
                                 CornerRadius="4"
-                                VerticalOptions="Center"
+                                Grid.Row="1"
+                                HeightRequest="8"
                                 HorizontalOptions="Center"
-                                BackgroundColor="Black" />
+                                IsVisible="{Binding ., Converter={StaticResource HasEventsToVisibilityConverter}}"
+                                VerticalOptions="Center"
+                                WidthRequest="8" />
                         </Grid>
-                        
                     </Frame>
                 </DataTemplate>
             </BindableLayout.ItemTemplate>

--- a/src/Xalendar.View/Controls/CalendarView.xaml.cs
+++ b/src/Xalendar.View/Controls/CalendarView.xaml.cs
@@ -24,18 +24,34 @@ namespace Xalendar.View.Controls
 
         private async void OnPreviousMonthClick(object sender, EventArgs e)
         {
-            await Task.Run(() => _monthContainer.Previous());
-            
-            BindableLayout.SetItemsSource(CalendarDaysContainer, _monthContainer.Days);
-            MonthName.Text = _monthContainer.GetName();
+            var result = await Task.Run(() =>
+            {
+                _monthContainer.Previous();
+                
+                var days = _monthContainer.Days;
+                var monthName = _monthContainer.GetName();
+
+                return (days, monthName);
+            });
+
+            BindableLayout.SetItemsSource(CalendarDaysContainer, result.days);
+            MonthName.Text = result.monthName;
         }
 
         private async void OnNextMonthClick(object sender, EventArgs e)
         {
-            await Task.Run(() => _monthContainer.Next());
+            var result = await Task.Run(() =>
+            {
+                _monthContainer.Next();
+                
+                var days = _monthContainer.Days;
+                var monthName = _monthContainer.GetName();
 
-            BindableLayout.SetItemsSource(CalendarDaysContainer, _monthContainer.Days);
-            MonthName.Text = _monthContainer.GetName();
+                return (days, monthName);
+            });
+
+            BindableLayout.SetItemsSource(CalendarDaysContainer, result.days);
+            MonthName.Text = result.monthName;
         }
     }
 }


### PR DESCRIPTION
Agora estamos usando o XAML Styler para formatar os arquivos de layout, então, formatei todos os arquivos da solução. No carregamento do calendário adicionei alguns métodos para serem carregados em background para diminuir um pouco o gargalo da UI thread.