### PR TITLE
Performance issues

### DIFF
--- a/src/Xalendar.Api.Tests/Models/MonthContainerTests.cs
+++ b/src/Xalendar.Api.Tests/Models/MonthContainerTests.cs
@@ -13,19 +13,19 @@ namespace Xalendar.Api.Tests.Models
     {
         [Test]
         [TestCaseSource(nameof(MonthsValuesTests))]
-        public void MonthContainerShouldContainsDaysOfMonthAndPreviousAndNext(DateTime dateTime, int totalOfDays)
+        public void MonthContainerShouldHave42Days(DateTime dateTime)
         {
             var monthContainer = new MonthContainer(dateTime);
 
             Assert.IsNotEmpty(monthContainer.Days);
-            Assert.AreEqual(totalOfDays, monthContainer.Days.Count);
+            Assert.AreEqual(42, monthContainer.Days.Count);
         }
 
         private static object[] MonthsValuesTests =
         {
-            new object[] { new DateTime(2020, 7, 23), 35 },
-            new object[] { new DateTime(2015, 2, 10), 28 },
-            new object[] { new DateTime(2020, 8, 1), 42 }
+            new object[] { new DateTime(2020, 7, 23) },
+            new object[] { new DateTime(2015, 2, 10) },
+            new object[] { new DateTime(2020, 8, 1) }
         };
 
         [Test]

--- a/src/Xalendar.Api/Extensions/MonthContainerExtension.cs
+++ b/src/Xalendar.Api/Extensions/MonthContainerExtension.cs
@@ -39,6 +39,10 @@ namespace Xalendar.Api.Extensions
             
             for (var index = 0; index < numberOfDaysToDiscard; index++)
                 daysOfContainer.Add(default(Day));
+
+            if (daysOfContainer.Count < 42)
+                for (var index = daysOfContainer.Count; index < 42; index++)
+                    daysOfContainer.Add(default(Day));
         }
     }
 }

--- a/src/Xalendar.View/Controls/CalendarView.xaml.cs
+++ b/src/Xalendar.View/Controls/CalendarView.xaml.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Xalendar.Api.Extensions;
 using Xalendar.Api.Models;
@@ -34,8 +35,8 @@ namespace Xalendar.View.Controls
                 return (days, monthName);
             });
 
-            BindableLayout.SetItemsSource(CalendarDaysContainer, result.days);
             MonthName.Text = result.monthName;
+            RecycleDays(result.days);
         }
 
         private async void OnNextMonthClick(object sender, EventArgs e)
@@ -49,9 +50,19 @@ namespace Xalendar.View.Controls
 
                 return (days, monthName);
             });
-
-            BindableLayout.SetItemsSource(CalendarDaysContainer, result.days);
+            
             MonthName.Text = result.monthName;
+            RecycleDays(result.days);
+        }
+
+        private void RecycleDays(IReadOnlyList<Day?> days)
+        {
+            for (var index = 0; index < CalendarDaysContainer.Children.Count; index++)
+            {
+                var dayContainer = days[index];
+                var dayView = CalendarDaysContainer.Children[index];
+                dayView.BindingContext = dayContainer;
+            }
         }
     }
 }


### PR DESCRIPTION
Na [12º live](https://www.youtube.com/watch?v=F4cRxNnX9HY) verificamos um problema de performance ao navegar entre os meses do calendário. Realizamos diversos testes, dentre eles:

- Mover o código da navegação dos meses para uma thread em background
- Remover o BindableLayout e iterar os itens manualmente no code behind
- Alterar estrutura de layout para usar Grid e StackLayout ao invés do FlexLayout
- Tentar cancelar processamento da mudança do mês caso o processamento de uma mudança já estivesse sendo processada

Em todos essas tentativas a navegação do calendário ainda continuava lenta, então, descobrimos que o problema estava para inflar os elementos na view - setar o `ItemSource` com a lista dos dias. 

Para resolver isso, essa PR faz a reciclagem dos itens que já estão na tela trocando o contexto de binding de cada item e atualizado os dias do mês.