### PR TITLE
Add events support in CalendarView

### DIFF
--- a/src/Xalendar.Api.Tests/Models/MonthContainerTests.cs
+++ b/src/Xalendar.Api.Tests/Models/MonthContainerTests.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.Linq;
 using NUnit.Framework;
 using Xalendar.Api.Extensions;
+using Xalendar.Api.Interfaces;
 using Xalendar.Api.Models;
 
 namespace Xalendar.Api.Tests.Models
@@ -54,7 +55,7 @@ namespace Xalendar.Api.Tests.Models
         {
             var dateTime = new DateTime(2020, 7, 9);
             var monthContainer = new MonthContainer(dateTime);
-            var events = new List<Event>
+            var events = new List<ICalendarViewEvent>
             {
                 new Event(1, "Name event", dateTime, dateTime, false)
             };

--- a/src/Xalendar.Api.Tests/Models/MonthTests.cs
+++ b/src/Xalendar.Api.Tests/Models/MonthTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using Xalendar.Api.Extensions;
+using Xalendar.Api.Interfaces;
 using Xalendar.Api.Models;
 
 namespace Xalendar.Api.Tests.Models
@@ -198,7 +199,7 @@ namespace Xalendar.Api.Tests.Models
         {
             var dateTime = new DateTime(2020, 1, 1);
             var month = new Month(dateTime);
-            var events = new List<Event>
+            var events = new List<ICalendarViewEvent>
             {
                 new Event(1, "Name", dateTime, dateTime, false)
             };
@@ -215,7 +216,7 @@ namespace Xalendar.Api.Tests.Models
         {
             var dateTime = new DateTime(2020, 1, 1);
             var month = new Month(dateTime);
-            var events = new List<Event>
+            var events = new List<ICalendarViewEvent>
             {
                 new Event(1, "Name", dateTime, dateTime, false),
                 new Event(2, "Name", dateTime.AddMonths(1), dateTime.AddMonths(1), false)

--- a/src/Xalendar.Api/Extensions/DayExtension.cs
+++ b/src/Xalendar.Api/Extensions/DayExtension.cs
@@ -1,11 +1,12 @@
 using System;
+using Xalendar.Api.Interfaces;
 using Xalendar.Api.Models;
 
 namespace Xalendar.Api.Extensions
 {
     public static class DayExtension
     {
-        public static void AddEvent(this Day day, Event @event)
+        public static void AddEvent(this Day day, ICalendarViewEvent @event)
         {
             day.Events.Add(@event);
         }

--- a/src/Xalendar.Api/Extensions/MonthContainerExtension.cs
+++ b/src/Xalendar.Api/Extensions/MonthContainerExtension.cs
@@ -9,7 +9,7 @@ namespace Xalendar.Api.Extensions
     {
         public static void SelectDay(this MonthContainer monthContainer, Day selectedDay) => monthContainer._month.SelectDay(selectedDay);
         public static Day GetSelectedDay(this MonthContainer monthContainer) => monthContainer._month.GetSelectedDay();
-        public static void AddEvents(this MonthContainer monthContainer, IList<ICalendarViewEvent> events) => monthContainer._month.AddEvents(events);
+        public static void AddEvents(this MonthContainer monthContainer, IEnumerable<ICalendarViewEvent> events) => monthContainer._month.AddEvents(events);
         public static string GetName(this MonthContainer monthContainer) => monthContainer._month.MonthDateTime.ToString("MMMM yyyy");
 
         public static void Next(this MonthContainer monthContainer)

--- a/src/Xalendar.Api/Extensions/MonthContainerExtension.cs
+++ b/src/Xalendar.Api/Extensions/MonthContainerExtension.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using Xalendar.Api.Interfaces;
 using Xalendar.Api.Models;
 
 namespace Xalendar.Api.Extensions
@@ -8,7 +9,7 @@ namespace Xalendar.Api.Extensions
     {
         public static void SelectDay(this MonthContainer monthContainer, Day selectedDay) => monthContainer._month.SelectDay(selectedDay);
         public static Day GetSelectedDay(this MonthContainer monthContainer) => monthContainer._month.GetSelectedDay();
-        public static void AddEvents(this MonthContainer monthContainer, IList<Event> events) => monthContainer._month.AddEvents(events);
+        public static void AddEvents(this MonthContainer monthContainer, IList<ICalendarViewEvent> events) => monthContainer._month.AddEvents(events);
         public static string GetName(this MonthContainer monthContainer) => monthContainer._month.MonthDateTime.ToString("MMMM yyyy");
 
         public static void Next(this MonthContainer monthContainer)

--- a/src/Xalendar.Api/Extensions/MonthExtension.cs
+++ b/src/Xalendar.Api/Extensions/MonthExtension.cs
@@ -47,7 +47,7 @@ namespace Xalendar.Api.Extensions
                 .ToList();
         }
 
-        public static void AddEvents(this Month month, IList<ICalendarViewEvent> events)
+        public static void AddEvents(this Month month, IEnumerable<ICalendarViewEvent> events)
         {
             foreach (var @event in events)
             {

--- a/src/Xalendar.Api/Extensions/MonthExtension.cs
+++ b/src/Xalendar.Api/Extensions/MonthExtension.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Xalendar.Api.Interfaces;
 using Xalendar.Api.Models;
 
 namespace Xalendar.Api.Extensions
@@ -46,7 +47,7 @@ namespace Xalendar.Api.Extensions
                 .ToList();
         }
 
-        public static void AddEvents(this Month month, IList<Event> events)
+        public static void AddEvents(this Month month, IList<ICalendarViewEvent> events)
         {
             foreach (var @event in events)
             {

--- a/src/Xalendar.Api/Interfaces/ICalendarViewEvent.cs
+++ b/src/Xalendar.Api/Interfaces/ICalendarViewEvent.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace Xalendar.Api.Interfaces
+{
+    public interface ICalendarViewEvent
+    {
+        object Id { get; }
+        string Name { get; }
+        DateTime StartDateTime { get; }
+        DateTime EndDateTime { get; }
+        bool IsAllDay { get; }
+    }
+}

--- a/src/Xalendar.Api/Models/Day.cs
+++ b/src/Xalendar.Api/Models/Day.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Xalendar.Api.Interfaces;
 
 namespace Xalendar.Api.Models
 {
@@ -8,7 +9,7 @@ namespace Xalendar.Api.Models
     {
         private DateTime _currentDateTime;
         public DateTime DateTime { get; }
-        public IList<Event> Events { get; }
+        public IList<ICalendarViewEvent> Events { get; }
 
         public bool IsWeekend => DateTime.DayOfWeek switch
         {
@@ -24,7 +25,7 @@ namespace Xalendar.Api.Models
             _currentDateTime = DateTime.Now;
             DateTime = dateTime;
             _isSelected = isSelected;
-            Events = new List<Event>();
+            Events = new List<ICalendarViewEvent>();
         }
 
         public Day(DateTime dateTime, DateTime currentDateTime, bool isSelected = false)
@@ -32,7 +33,7 @@ namespace Xalendar.Api.Models
             _currentDateTime = currentDateTime;
             DateTime = dateTime;
             _isSelected = isSelected;
-            Events = new List<Event>();
+            Events = new List<ICalendarViewEvent>();
         }
 
         public bool IsToday => _currentDateTime.Date == DateTime.Date;

--- a/src/Xalendar.Api/Models/Event.cs
+++ b/src/Xalendar.Api/Models/Event.cs
@@ -1,8 +1,9 @@
 using System;
+using Xalendar.Api.Interfaces;
 
 namespace Xalendar.Api.Models
 {
-    public class Event
+    public class Event : ICalendarViewEvent
     {
         public object Id { get; private set; }
         public string Name { get; private set; }

--- a/src/Xalendar.Sample/Xalendar.Sample/MainPage.xaml
+++ b/src/Xalendar.Sample/Xalendar.Sample/MainPage.xaml
@@ -7,6 +7,6 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:xalendar="clr-namespace:Xalendar.View.Controls;assembly=Xalendar.View">
     <StackLayout>
-        <xalendar:CalendarView />
+        <xalendar:CalendarView x:Name="Calendar" />
     </StackLayout>
 </ContentPage>

--- a/src/Xalendar.Sample/Xalendar.Sample/MainPage.xaml
+++ b/src/Xalendar.Sample/Xalendar.Sample/MainPage.xaml
@@ -7,6 +7,13 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:xalendar="clr-namespace:Xalendar.View.Controls;assembly=Xalendar.View">
     <StackLayout>
-        <xalendar:CalendarView x:Name="Calendar" />
+        <xalendar:CalendarView Events="{Binding Events}" />
+
+        <Button
+            BackgroundColor="DodgerBlue"
+            Clicked="OnRandomButtonClick"
+            Margin="20,0"
+            Text="Add random event"
+            TextColor="White" />
     </StackLayout>
 </ContentPage>

--- a/src/Xalendar.Sample/Xalendar.Sample/MainPage.xaml.cs
+++ b/src/Xalendar.Sample/Xalendar.Sample/MainPage.xaml.cs
@@ -1,10 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.Collections.ObjectModel;
 using Xalendar.Api.Interfaces;
-using Xalendar.Api.Models;
 using Xamarin.Forms;
 
 namespace Xalendar.Sample
@@ -14,16 +10,39 @@ namespace Xalendar.Sample
         public MainPage()
         {
             InitializeComponent();
+            BindingContext = new MainPageViewModel();
+        }
+        
+        private void OnRandomButtonClick(object sender, EventArgs e)
+        {
+            if (BindingContext is MainPageViewModel viewModel)
+                viewModel.AddRandomEvent();
+        }
+    }
 
-            var events = new List<ICalendarViewEvent>();
-
+    public class MainPageViewModel
+    {
+        public ObservableCollection<ICalendarViewEvent> Events { get; }
+    
+        public MainPageViewModel()
+        {
+            Events = new ObservableCollection<ICalendarViewEvent>();
+    
             for (var index = 1; index <= 10; index++)
             {
                 var eventDate = new DateTime(2020, 9, index);
-                events.Add(new CustomEvent(index, "Nome evento", eventDate, eventDate, false));
+                Events.Add(new CustomEvent(index, "Nome evento", eventDate, eventDate, false));
             }
-            
-            Calendar.Events = events;
+        }
+    
+        private int _dayEventToStart = 11;
+        
+        public void AddRandomEvent()
+        {
+            var eventDate = new DateTime(2020, 9, _dayEventToStart);
+            var customEvent = new CustomEvent(_dayEventToStart, "Nome evento", eventDate, eventDate, false);
+            Events.Add(customEvent);
+            _dayEventToStart++;
         }
     }
 

--- a/src/Xalendar.Sample/Xalendar.Sample/MainPage.xaml.cs
+++ b/src/Xalendar.Sample/Xalendar.Sample/MainPage.xaml.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Xalendar.Api.Interfaces;
 using Xalendar.Api.Models;
 using Xamarin.Forms;
 
@@ -14,15 +15,33 @@ namespace Xalendar.Sample
         {
             InitializeComponent();
 
-            var events = new List<Event>();
+            var events = new List<ICalendarViewEvent>();
 
             for (var index = 1; index <= 10; index++)
             {
                 var eventDate = new DateTime(2020, 9, index);
-                events.Add(new Event(index, "Nome evento", eventDate, eventDate, false));
+                events.Add(new CustomEvent(index, "Nome evento", eventDate, eventDate, false));
             }
             
             Calendar.Events = events;
+        }
+    }
+
+    public class CustomEvent : ICalendarViewEvent
+    {
+        public object Id { get; }
+        public string Name { get; }
+        public DateTime StartDateTime { get; }
+        public DateTime EndDateTime { get; }
+        public bool IsAllDay { get; }
+        
+        public CustomEvent(object id, string name, DateTime startDateTime, DateTime endDateTime, bool isAllDay)
+        {
+            Id = id;
+            Name = name;
+            StartDateTime = startDateTime;
+            EndDateTime = endDateTime;
+            IsAllDay = isAllDay;
         }
     }
 }

--- a/src/Xalendar.Sample/Xalendar.Sample/MainPage.xaml.cs
+++ b/src/Xalendar.Sample/Xalendar.Sample/MainPage.xaml.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Xalendar.Api.Models;
 using Xamarin.Forms;
 
 namespace Xalendar.Sample
@@ -12,6 +13,16 @@ namespace Xalendar.Sample
         public MainPage()
         {
             InitializeComponent();
+
+            var events = new List<Event>();
+
+            for (var index = 1; index <= 10; index++)
+            {
+                var eventDate = new DateTime(2020, 9, index);
+                events.Add(new Event(index, "Nome evento", eventDate, eventDate, false));
+            }
+            
+            Calendar.Events = events;
         }
     }
 }

--- a/src/Xalendar.View/Controls/CalendarDay.xaml
+++ b/src/Xalendar.View/Controls/CalendarDay.xaml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8" ?>
+
+<ContentView
+    x:Class="Xalendar.View.Controls.CalendarDay"
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
+    <ContentView.Resources>
+        <ResourceDictionary>
+            <FlexBasis x:Key="DayWidth">14.28%</FlexBasis>
+        </ResourceDictionary>
+    </ContentView.Resources>
+
+    <ContentView.Content>
+        <Frame
+            CornerRadius="20"
+            FlexLayout.Basis="{StaticResource DayWidth}"
+            HasShadow="false"
+            HeightRequest="56"
+            Padding="0"
+            x:Name="DayContainer">
+            <Grid RowSpacing="0" VerticalOptions="Center">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="14" />
+                </Grid.RowDefinitions>
+
+                <Label
+                    FontSize="Subtitle"
+                    Grid.Row="0"
+                    HorizontalTextAlignment="Center"
+                    VerticalTextAlignment="Center"
+                    x:Name="DayElement" />
+
+                <BoxView
+                    BackgroundColor="Black"
+                    CornerRadius="4"
+                    Grid.Row="1"
+                    HeightRequest="8"
+                    HorizontalOptions="Center"
+                    VerticalOptions="Center"
+                    WidthRequest="8"
+                    x:Name="HasEventsElement" />
+            </Grid>
+        </Frame>
+    </ContentView.Content>
+</ContentView>

--- a/src/Xalendar.View/Controls/CalendarDay.xaml
+++ b/src/Xalendar.View/Controls/CalendarDay.xaml
@@ -1,19 +1,13 @@
 <?xml version="1.0" encoding="utf-8" ?>
 
 <ContentView
+    FlexLayout.Basis="14.28%"
     x:Class="Xalendar.View.Controls.CalendarDay"
     xmlns="http://xamarin.com/schemas/2014/forms"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
-    <ContentView.Resources>
-        <ResourceDictionary>
-            <FlexBasis x:Key="DayWidth">14.28%</FlexBasis>
-        </ResourceDictionary>
-    </ContentView.Resources>
-
     <ContentView.Content>
         <Frame
             CornerRadius="20"
-            FlexLayout.Basis="{StaticResource DayWidth}"
             HasShadow="false"
             HeightRequest="56"
             Padding="0"

--- a/src/Xalendar.View/Controls/CalendarDay.xaml.cs
+++ b/src/Xalendar.View/Controls/CalendarDay.xaml.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace Xalendar.View.Controls
+{
+    [XamlCompilation(XamlCompilationOptions.Compile)]
+    public partial class CalendarDay : ContentView
+    {
+        public CalendarDay()
+        {
+            InitializeComponent();
+        }
+    }
+}
+

--- a/src/Xalendar.View/Controls/CalendarView.xaml
+++ b/src/Xalendar.View/Controls/CalendarView.xaml
@@ -73,7 +73,8 @@
                                 HorizontalOptions="Center"
                                 IsVisible="{Binding ., Converter={StaticResource HasEventsToVisibilityConverter}}"
                                 VerticalOptions="Center"
-                                WidthRequest="8" />
+                                WidthRequest="8"
+                                x:Name="HasEventsElement" />
                         </Grid>
                     </Frame>
                 </DataTemplate>

--- a/src/Xalendar.View/Controls/CalendarView.xaml
+++ b/src/Xalendar.View/Controls/CalendarView.xaml
@@ -46,13 +46,13 @@
             <BindableLayout.ItemTemplate>
                 <DataTemplate>
                     <Frame
-                        x:Name="DayContainer"
                         BackgroundColor="{Binding ., Converter={StaticResource IsTodayToBackgroundColorConverter}}"
                         CornerRadius="20"
                         FlexLayout.Basis="{StaticResource DayWidth}"
                         HasShadow="false"
                         HeightRequest="56"
-                        Padding="0">
+                        Padding="0"
+                        x:Name="DayContainer">
                         <Grid RowSpacing="0" VerticalOptions="Center">
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="Auto" />
@@ -64,7 +64,8 @@
                                 Grid.Row="0"
                                 HorizontalTextAlignment="Center"
                                 Text="{Binding .}"
-                                VerticalTextAlignment="Center" />
+                                VerticalTextAlignment="Center"
+                                x:Name="DayElement" />
 
                             <BoxView
                                 BackgroundColor="Black"

--- a/src/Xalendar.View/Controls/CalendarView.xaml
+++ b/src/Xalendar.View/Controls/CalendarView.xaml
@@ -43,12 +43,6 @@
             </BindableLayout.ItemTemplate>
         </FlexLayout>
 
-        <FlexLayout Wrap="Wrap" x:Name="CalendarDaysContainer">
-            <BindableLayout.ItemTemplate>
-                <DataTemplate>
-                    <controls:CalendarDay />
-                </DataTemplate>
-            </BindableLayout.ItemTemplate>
-        </FlexLayout>
+        <FlexLayout Wrap="Wrap" x:Name="CalendarDaysContainer" />
     </StackLayout>
 </ContentView>

--- a/src/Xalendar.View/Controls/CalendarView.xaml
+++ b/src/Xalendar.View/Controls/CalendarView.xaml
@@ -46,6 +46,7 @@
             <BindableLayout.ItemTemplate>
                 <DataTemplate>
                     <Frame
+                        x:Name="DayContainer"
                         BackgroundColor="{Binding ., Converter={StaticResource IsTodayToBackgroundColorConverter}}"
                         CornerRadius="20"
                         FlexLayout.Basis="{StaticResource DayWidth}"

--- a/src/Xalendar.View/Controls/CalendarView.xaml
+++ b/src/Xalendar.View/Controls/CalendarView.xaml
@@ -2,6 +2,7 @@
 <ContentView
     x:Class="Xalendar.View.Controls.CalendarView"
     xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:controls="clr-namespace:Xalendar.View.Controls;assembly=Xalendar.View"
     xmlns:converters="clr-namespace:Xalendar.View.Converters;assembly=Xalendar.View"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
     <ContentView.Resources>
@@ -45,40 +46,7 @@
         <FlexLayout Wrap="Wrap" x:Name="CalendarDaysContainer">
             <BindableLayout.ItemTemplate>
                 <DataTemplate>
-                    <Frame
-                        BackgroundColor="{Binding ., Converter={StaticResource IsTodayToBackgroundColorConverter}}"
-                        CornerRadius="20"
-                        FlexLayout.Basis="{StaticResource DayWidth}"
-                        HasShadow="false"
-                        HeightRequest="56"
-                        Padding="0"
-                        x:Name="DayContainer">
-                        <Grid RowSpacing="0" VerticalOptions="Center">
-                            <Grid.RowDefinitions>
-                                <RowDefinition Height="Auto" />
-                                <RowDefinition Height="14" />
-                            </Grid.RowDefinitions>
-
-                            <Label
-                                FontSize="Subtitle"
-                                Grid.Row="0"
-                                HorizontalTextAlignment="Center"
-                                Text="{Binding .}"
-                                VerticalTextAlignment="Center"
-                                x:Name="DayElement" />
-
-                            <BoxView
-                                BackgroundColor="Black"
-                                CornerRadius="4"
-                                Grid.Row="1"
-                                HeightRequest="8"
-                                HorizontalOptions="Center"
-                                IsVisible="{Binding ., Converter={StaticResource HasEventsToVisibilityConverter}}"
-                                VerticalOptions="Center"
-                                WidthRequest="8"
-                                x:Name="HasEventsElement" />
-                        </Grid>
-                    </Frame>
+                    <controls:CalendarDay />
                 </DataTemplate>
             </BindableLayout.ItemTemplate>
         </FlexLayout>

--- a/src/Xalendar.View/Controls/CalendarView.xaml.cs
+++ b/src/Xalendar.View/Controls/CalendarView.xaml.cs
@@ -92,6 +92,9 @@ namespace Xalendar.View.Controls
 
                 if (view.FindByName<XView>("HasEventsElement") is {} hasEventsElement)
                     hasEventsElement.IsVisible = day?.HasEvents ?? false;
+
+                if (view.FindByName<XView>("DayContainer") is {} dayContainer)
+                    dayContainer.BackgroundColor = day is {} && day.IsToday ? Color.Red : Color.Transparent;
             }
         }
     }

--- a/src/Xalendar.View/Controls/CalendarView.xaml.cs
+++ b/src/Xalendar.View/Controls/CalendarView.xaml.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Xalendar.Api.Extensions;
+using Xalendar.Api.Interfaces;
 using Xalendar.Api.Models;
 using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
@@ -15,21 +16,21 @@ namespace Xalendar.View.Controls
         public static BindableProperty EventsProperty =
             BindableProperty.Create(
                 nameof(Events),
-                typeof(IList<Event>),
+                typeof(IList<ICalendarViewEvent>),
                 typeof(CalendarView),
                 null,
                 BindingMode.OneWay,
                 propertyChanged: OnEventsChanged);
         
-        public IList<Event> Events
+        public IList<ICalendarViewEvent> Events
         {
-            get => (IList<Event>)GetValue(EventsProperty);
+            get => (IList<ICalendarViewEvent>)GetValue(EventsProperty);
             set => SetValue(EventsProperty, value);
         }
         
         private static void OnEventsChanged(BindableObject bindable, object oldvalue, object newvalue)
         {
-            if (bindable is CalendarView calendarView && newvalue is IList<Event> events)
+            if (bindable is CalendarView calendarView && newvalue is IList<ICalendarViewEvent> events)
             {
                 calendarView._monthContainer.AddEvents(events);
                 calendarView.RecycleDays(calendarView._monthContainer.Days);

--- a/src/Xalendar.View/Controls/CalendarView.xaml.cs
+++ b/src/Xalendar.View/Controls/CalendarView.xaml.cs
@@ -95,6 +95,9 @@ namespace Xalendar.View.Controls
 
                 if (view.FindByName<XView>("DayContainer") is {} dayContainer)
                     dayContainer.BackgroundColor = day is {} && day.IsToday ? Color.Red : Color.Transparent;
+
+                if (view.FindByName<Label>("DayElement") is {} dayElement)
+                    dayElement.Text = day?.ToString();
             }
         }
     }

--- a/src/Xalendar.View/Controls/CalendarView.xaml.cs
+++ b/src/Xalendar.View/Controls/CalendarView.xaml.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.Linq;
 using System.Threading.Tasks;
 using Xalendar.Api.Extensions;
 using Xalendar.Api.Interfaces;
@@ -45,11 +46,7 @@ namespace Xalendar.View.Controls
                 
                 void OnEventsCollectionChanged(object sender, NotifyCollectionChangedEventArgs args)
                 {
-                    var notifiedEvents = new List<ICalendarViewEvent>();
-                    
-                    foreach (ICalendarViewEvent item in args.NewItems)
-                        notifiedEvents.Add(item);
-                    
+                    var notifiedEvents = args.NewItems.Cast<ICalendarViewEvent>();
                     UpdateEvents(calendarView, notifiedEvents);
                 }
             }

--- a/src/Xalendar.View/Controls/CalendarView.xaml.cs
+++ b/src/Xalendar.View/Controls/CalendarView.xaml.cs
@@ -5,6 +5,7 @@ using Xalendar.Api.Extensions;
 using Xalendar.Api.Models;
 using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
+using XView = Xamarin.Forms.View;
 
 namespace Xalendar.View.Controls
 {
@@ -89,7 +90,7 @@ namespace Xalendar.View.Controls
                 var view = CalendarDaysContainer.Children[index];
                 view.BindingContext = day;
 
-                if (view.FindByName<BoxView>("HasEventsElement") is {} hasEventsElement)
+                if (view.FindByName<XView>("HasEventsElement") is {} hasEventsElement)
                     hasEventsElement.IsVisible = day?.HasEvents ?? false;
             }
         }

--- a/src/Xalendar.View/Controls/CalendarView.xaml.cs
+++ b/src/Xalendar.View/Controls/CalendarView.xaml.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Threading.Tasks;
@@ -17,15 +18,15 @@ namespace Xalendar.View.Controls
         public static BindableProperty EventsProperty =
             BindableProperty.Create(
                 nameof(Events),
-                typeof(IList<ICalendarViewEvent>),
+                typeof(IEnumerable<ICalendarViewEvent>),
                 typeof(CalendarView),
                 null,
                 BindingMode.OneWay,
                 propertyChanged: OnEventsChanged);
         
-        public IList<ICalendarViewEvent> Events
+        public IEnumerable<ICalendarViewEvent> Events
         {
-            get => (IList<ICalendarViewEvent>)GetValue(EventsProperty);
+            get => (IEnumerable<ICalendarViewEvent>)GetValue(EventsProperty);
             set => SetValue(EventsProperty, value);
         }
         
@@ -39,7 +40,7 @@ namespace Xalendar.View.Controls
                 if (newvalue is INotifyCollectionChanged newEvents)
                     newEvents.CollectionChanged += OnEventsCollectionChanged;
 
-                if (newvalue is IList<ICalendarViewEvent> events)
+                if (newvalue is IEnumerable<ICalendarViewEvent> events)
                 {
                     calendarView._monthContainer.AddEvents(events);
                     calendarView.RecycleDays(calendarView._monthContainer.Days);

--- a/src/Xalendar.View/Controls/CalendarView.xaml.cs
+++ b/src/Xalendar.View/Controls/CalendarView.xaml.cs
@@ -36,6 +36,7 @@ namespace Xalendar.View.Controls
         }
         
         private readonly MonthContainer _monthContainer;
+        private readonly int _numberOfDaysInContainer;
         
         public CalendarView()
         {
@@ -45,6 +46,7 @@ namespace Xalendar.View.Controls
             BindableLayout.SetItemsSource(CalendarDaysContainer, _monthContainer.Days);
             BindableLayout.SetItemsSource(CalendarDaysOfWeekContainer, _monthContainer.DaysOfWeek);
             MonthName.Text = _monthContainer.GetName();
+            _numberOfDaysInContainer = CalendarDaysContainer.Children.Count;
         }
 
         private async void OnPreviousMonthClick(object sender, EventArgs e)
@@ -81,7 +83,7 @@ namespace Xalendar.View.Controls
 
         private void RecycleDays(IReadOnlyList<Day?> days)
         {
-            for (var index = 0; index < CalendarDaysContainer.Children.Count; index++)
+            for (var index = 0; index < _numberOfDaysInContainer; index++)
             {
                 var day = days[index];
                 var view = CalendarDaysContainer.Children[index];

--- a/src/Xalendar.View/Controls/CalendarView.xaml.cs
+++ b/src/Xalendar.View/Controls/CalendarView.xaml.cs
@@ -17,12 +17,22 @@ namespace Xalendar.View.Controls
                 typeof(IList<Event>),
                 typeof(CalendarView),
                 null,
-                BindingMode.OneWay);
-
+                BindingMode.OneWay,
+                propertyChanged: OnEventsChanged);
+        
         public IList<Event> Events
         {
             get => (IList<Event>)GetValue(EventsProperty);
             set => SetValue(EventsProperty, value);
+        }
+        
+        private static void OnEventsChanged(BindableObject bindable, object oldvalue, object newvalue)
+        {
+            if (bindable is CalendarView calendarView && newvalue is IList<Event> events)
+            {
+                calendarView._monthContainer.AddEvents(events);
+                calendarView.RecycleDays(calendarView._monthContainer.Days);
+            }
         }
         
         private readonly MonthContainer _monthContainer;
@@ -73,9 +83,12 @@ namespace Xalendar.View.Controls
         {
             for (var index = 0; index < CalendarDaysContainer.Children.Count; index++)
             {
-                var dayContainer = days[index];
-                var dayView = CalendarDaysContainer.Children[index];
-                dayView.BindingContext = dayContainer;
+                var day = days[index];
+                var view = CalendarDaysContainer.Children[index];
+                view.BindingContext = day;
+
+                if (view.FindByName<BoxView>("HasEventsElement") is {} hasEventsElement)
+                    hasEventsElement.IsVisible = day?.HasEvents ?? false;
             }
         }
     }

--- a/src/Xalendar.View/Controls/CalendarView.xaml.cs
+++ b/src/Xalendar.View/Controls/CalendarView.xaml.cs
@@ -11,6 +11,20 @@ namespace Xalendar.View.Controls
     [XamlCompilation(XamlCompilationOptions.Compile)]
     public partial class CalendarView : ContentView
     {
+        public static BindableProperty EventsProperty =
+            BindableProperty.Create(
+                nameof(Events),
+                typeof(IList<Event>),
+                typeof(CalendarView),
+                null,
+                BindingMode.OneWay);
+
+        public IList<Event> Events
+        {
+            get => (IList<Event>)GetValue(EventsProperty);
+            set => SetValue(EventsProperty, value);
+        }
+        
         private readonly MonthContainer _monthContainer;
         
         public CalendarView()

--- a/src/Xalendar.View/Controls/CalendarView.xaml.cs
+++ b/src/Xalendar.View/Controls/CalendarView.xaml.cs
@@ -88,7 +88,6 @@ namespace Xalendar.View.Controls
             {
                 var day = days[index];
                 var view = CalendarDaysContainer.Children[index];
-                view.BindingContext = day;
 
                 if (view.FindByName<XView>("HasEventsElement") is {} hasEventsElement)
                     hasEventsElement.IsVisible = day?.HasEvents ?? false;

--- a/src/Xalendar.View/Controls/CalendarView.xaml.cs
+++ b/src/Xalendar.View/Controls/CalendarView.xaml.cs
@@ -41,10 +41,7 @@ namespace Xalendar.View.Controls
                     newEvents.CollectionChanged += OnEventsCollectionChanged;
 
                 if (newvalue is IEnumerable<ICalendarViewEvent> events)
-                {
-                    calendarView._monthContainer.AddEvents(events);
-                    calendarView.RecycleDays(calendarView._monthContainer.Days);
-                }
+                    UpdateEvents(calendarView, events);
                 
                 void OnEventsCollectionChanged(object sender, NotifyCollectionChangedEventArgs args)
                 {
@@ -53,10 +50,15 @@ namespace Xalendar.View.Controls
                     foreach (ICalendarViewEvent item in args.NewItems)
                         notifiedEvents.Add(item);
                     
-                    calendarView._monthContainer.AddEvents(notifiedEvents);
-                    calendarView.RecycleDays(calendarView._monthContainer.Days);
+                    UpdateEvents(calendarView, notifiedEvents);
                 }
             }
+        }
+        
+        private static void UpdateEvents(CalendarView calendarView, IEnumerable<ICalendarViewEvent> events)
+        {
+            calendarView._monthContainer.AddEvents(events);
+            calendarView.RecycleDays(calendarView._monthContainer.Days);
         }
 
 

--- a/src/Xalendar.View/Controls/CalendarView.xaml.cs
+++ b/src/Xalendar.View/Controls/CalendarView.xaml.cs
@@ -44,10 +44,15 @@ namespace Xalendar.View.Controls
             InitializeComponent();
             
             _monthContainer = new MonthContainer(DateTime.Today);
-            BindableLayout.SetItemsSource(CalendarDaysContainer, _monthContainer.Days);
+
+            var days = _monthContainer.Days;
+            _numberOfDaysInContainer = days.Count;
+            foreach (var _ in days)
+                CalendarDaysContainer.Children.Add(new CalendarDay());
+            RecycleDays(days);
+            
             BindableLayout.SetItemsSource(CalendarDaysOfWeekContainer, _monthContainer.DaysOfWeek);
             MonthName.Text = _monthContainer.GetName();
-            _numberOfDaysInContainer = CalendarDaysContainer.Children.Count;
         }
 
         private async void OnPreviousMonthClick(object sender, EventArgs e)


### PR DESCRIPTION
Foi adicionada uma _BindableProperty_  **EventsProperty** para popular os eventos do calendário. Também foi criada a interface **ICalendarViewEvent** para ser implementado na classe que armazena a informação dos eventos. A implementação dessa interface vai permitir que seja utilizada qualquer classe do app que implemente essa interface para listar os eventos.