### PR TITLE
Adiciona suporte para remover eventos do calendário

### DIFF
--- a/src/Xalendar.Api.Tests/Models/DayTests.cs
+++ b/src/Xalendar.Api.Tests/Models/DayTests.cs
@@ -198,5 +198,17 @@ namespace Xalendar.Api.Tests.Models
             
             Assert.IsEmpty(day.Events);
         }
+
+        [Test]
+        public void AllEventsShouldBeRemoved()
+        {
+            var day = new Day(DateTime.Now);
+            var @event = new Event(1, "Name", DateTime.Now, DateTime.Now, false);
+            day.AddEvent(@event);
+            
+            day.RemoveAllEvents();
+            
+            Assert.IsEmpty(day.Events);
+        }
     }
 }

--- a/src/Xalendar.Api.Tests/Models/DayTests.cs
+++ b/src/Xalendar.Api.Tests/Models/DayTests.cs
@@ -186,5 +186,17 @@ namespace Xalendar.Api.Tests.Models
             new object[] { new DateTime(2020, 7, 4), true },
             new object[] { new DateTime(2020, 7, 5), true }
         };
+
+        [Test]
+        public void EventsShouldBeRemoved()
+        {
+            var day = new Day(DateTime.Now);
+            var @event = new Event(1, "Name", DateTime.Now, DateTime.Now, false);
+            day.AddEvent(@event);
+            
+            day.RemoveEvent(@event);
+            
+            Assert.IsEmpty(day.Events);
+        }
     }
 }

--- a/src/Xalendar.Api.Tests/Models/MonthContainerTests.cs
+++ b/src/Xalendar.Api.Tests/Models/MonthContainerTests.cs
@@ -132,5 +132,19 @@ namespace Xalendar.Api.Tests.Models
 
             Assert.IsFalse(monthContainer._month.Days.Any(day => day.HasEvents));
         }
+
+        [Test]
+        public void AllEventsShouldBeRemovedFromMonthContainer()
+        {
+            var dateTime = new DateTime(2020, 7, 9);
+            var monthContainer = new MonthContainer(dateTime);
+            var calendarViewEvent = new Event(1, "Name event", dateTime, dateTime, false);
+            var events = new List<ICalendarViewEvent> {calendarViewEvent};
+            monthContainer.AddEvents(events);
+            
+            monthContainer.RemoveAllEvents();
+
+            Assert.IsFalse(monthContainer._month.Days.Any(day => day.HasEvents));
+        }
     }
 }

--- a/src/Xalendar.Api.Tests/Models/MonthContainerTests.cs
+++ b/src/Xalendar.Api.Tests/Models/MonthContainerTests.cs
@@ -118,5 +118,19 @@ namespace Xalendar.Api.Tests.Models
             new object[] { "en-US", "SUN" },
             new object[] { "fr-FR", "DIM" }
         };
+
+        [Test]
+        public void EventsShouldBeRemovedFromMonthContainer()
+        {
+            var dateTime = new DateTime(2020, 7, 9);
+            var monthContainer = new MonthContainer(dateTime);
+            var calendarViewEvent = new Event(1, "Name event", dateTime, dateTime, false);
+            var events = new List<ICalendarViewEvent> {calendarViewEvent};
+            monthContainer.AddEvents(events);
+            
+            monthContainer.RemoveEvent(calendarViewEvent);
+
+            Assert.IsFalse(monthContainer._month.Days.Any(day => day.HasEvents));
+        }
     }
 }

--- a/src/Xalendar.Api.Tests/Models/MonthTests.cs
+++ b/src/Xalendar.Api.Tests/Models/MonthTests.cs
@@ -272,5 +272,20 @@ namespace Xalendar.Api.Tests.Models
             var eventsOfMonth = month.Days.Where(day => day.Events.Any());
             Assert.IsEmpty(eventsOfMonth);
         }
+        
+        [Test]
+        public void AllEventsOfMonthShouldBeRemoved()
+        {
+            var dateTime = new DateTime(2020, 1, 1);
+            var month = new Month(dateTime);
+            var calendarViewEvent = new Event(1, "Name", dateTime, dateTime, false);
+            var events = new List<ICalendarViewEvent> {calendarViewEvent};
+            month.AddEvents(events);
+            
+            month.RemoveAllEvents();
+            
+            var eventsOfMonth = month.Days.Where(day => day.Events.Any());
+            Assert.IsEmpty(eventsOfMonth);
+        }
     }
 }

--- a/src/Xalendar.Api.Tests/Models/MonthTests.cs
+++ b/src/Xalendar.Api.Tests/Models/MonthTests.cs
@@ -228,5 +228,49 @@ namespace Xalendar.Api.Tests.Models
             Assert.IsNotEmpty(eventsOfMonth);
             Assert.AreEqual(1, eventsOfMonth.Count());
         }
+
+        [Test]
+        public void EventsFromCurrentMonthShouldBeRemoved()
+        {
+            var dateTime = new DateTime(2020, 1, 1);
+            var month = new Month(dateTime);
+            var calendarViewEvent = new Event(1, "Name", dateTime, dateTime, false);
+            var events = new List<ICalendarViewEvent> {calendarViewEvent};
+            month.AddEvents(events);
+            
+            month.RemoveEvent(calendarViewEvent);
+            
+            var eventsOfMonth = month.Days.Where(day => day.Events.Any());
+            Assert.IsEmpty(eventsOfMonth);
+        }
+
+        [Test]
+        public void EventsFromAnotherMonthNotShouldBeRemoved()
+        {
+            var dateTime = new DateTime(2020, 1, 1);
+            var month = new Month(dateTime);
+            var calendarViewEvent = new Event(1, "Name", dateTime, dateTime, false);
+            var events = new List<ICalendarViewEvent> {calendarViewEvent};
+            month.AddEvents(events);
+            var eventFromPreviousMonth = new Event(1, "Name", dateTime.AddMonths(-1), dateTime.AddMonths(-1), false);
+            
+            month.RemoveEvent(eventFromPreviousMonth);
+            
+            var eventsOfMonth = month.Days.Where(day => day.Events.Any());
+            Assert.IsNotEmpty(eventsOfMonth);
+        }
+
+        [Test]
+        public void EventsNotAddedNotShouldBeRemoved()
+        {
+            var dateTime = new DateTime(2020, 1, 1);
+            var month = new Month(dateTime);
+            var calendarViewEvent = new Event(1, "Name", dateTime, dateTime, false);
+            
+            month.RemoveEvent(calendarViewEvent);
+            
+            var eventsOfMonth = month.Days.Where(day => day.Events.Any());
+            Assert.IsEmpty(eventsOfMonth);
+        }
     }
 }

--- a/src/Xalendar.Api/Extensions/DayExtension.cs
+++ b/src/Xalendar.Api/Extensions/DayExtension.cs
@@ -10,5 +10,10 @@ namespace Xalendar.Api.Extensions
         {
             day.Events.Add(@event);
         }
+
+        public static void RemoveEvent(this Day day, ICalendarViewEvent @event)
+        {
+            day.Events.Remove(@event);
+        }
     }
 }

--- a/src/Xalendar.Api/Extensions/DayExtension.cs
+++ b/src/Xalendar.Api/Extensions/DayExtension.cs
@@ -15,5 +15,10 @@ namespace Xalendar.Api.Extensions
         {
             day.Events.Remove(@event);
         }
+
+        public static void RemoveAllEvents(this Day day)
+        {
+            day.Events.Clear();
+        }
     }
 }

--- a/src/Xalendar.Api/Extensions/MonthContainerExtension.cs
+++ b/src/Xalendar.Api/Extensions/MonthContainerExtension.cs
@@ -10,6 +10,10 @@ namespace Xalendar.Api.Extensions
         public static void SelectDay(this MonthContainer monthContainer, Day selectedDay) => monthContainer._month.SelectDay(selectedDay);
         public static Day GetSelectedDay(this MonthContainer monthContainer) => monthContainer._month.GetSelectedDay();
         public static void AddEvents(this MonthContainer monthContainer, IEnumerable<ICalendarViewEvent> events) => monthContainer._month.AddEvents(events);
+
+        public static void RemoveEvent(this MonthContainer monthContainer, ICalendarViewEvent calendarViewEvent) =>
+            monthContainer._month.RemoveEvent(calendarViewEvent);
+        
         public static string GetName(this MonthContainer monthContainer) => monthContainer._month.MonthDateTime.ToString("MMMM yyyy");
 
         public static void Next(this MonthContainer monthContainer)

--- a/src/Xalendar.Api/Extensions/MonthContainerExtension.cs
+++ b/src/Xalendar.Api/Extensions/MonthContainerExtension.cs
@@ -13,6 +13,9 @@ namespace Xalendar.Api.Extensions
 
         public static void RemoveEvent(this MonthContainer monthContainer, ICalendarViewEvent calendarViewEvent) =>
             monthContainer._month.RemoveEvent(calendarViewEvent);
+
+        public static void RemoveAllEvents(this MonthContainer monthContainer) =>
+            monthContainer._month.RemoveAllEvents();
         
         public static string GetName(this MonthContainer monthContainer) => monthContainer._month.MonthDateTime.ToString("MMMM yyyy");
 

--- a/src/Xalendar.Api/Extensions/MonthExtension.cs
+++ b/src/Xalendar.Api/Extensions/MonthExtension.cs
@@ -55,5 +55,11 @@ namespace Xalendar.Api.Extensions
                 month.Days.FirstOrDefault(day => day.DateTime.Date.Equals(eventDate))?.AddEvent(@event);
             }
         }
+
+        public static void RemoveEvent(this Month month, ICalendarViewEvent calendarViewEvent)
+        {
+            var eventDate = calendarViewEvent.StartDateTime.Date;
+            month.Days.FirstOrDefault(day => day.DateTime.Date.Equals(eventDate))?.RemoveEvent(calendarViewEvent);
+        }
     }
 }

--- a/src/Xalendar.Api/Extensions/MonthExtension.cs
+++ b/src/Xalendar.Api/Extensions/MonthExtension.cs
@@ -61,5 +61,11 @@ namespace Xalendar.Api.Extensions
             var eventDate = calendarViewEvent.StartDateTime.Date;
             month.Days.FirstOrDefault(day => day.DateTime.Date.Equals(eventDate))?.RemoveEvent(calendarViewEvent);
         }
+
+        public static void RemoveAllEvents(this Month month)
+        {
+            foreach (var day in month.Days)
+                day.RemoveAllEvents();
+        }
     }
 }

--- a/src/Xalendar.Sample/Xalendar.Sample/MainPage.xaml
+++ b/src/Xalendar.Sample/Xalendar.Sample/MainPage.xaml
@@ -23,6 +23,13 @@
                 Margin="20,0"
                 Text="Remove event"
                 TextColor="White" />
+
+            <Button
+                BackgroundColor="Indigo"
+                Command="{Binding RemoveAllEventsCommand}"
+                Margin="20,0"
+                Text="Remove all events"
+                TextColor="White" />
         </StackLayout>
     </ScrollView>
 </ContentPage>

--- a/src/Xalendar.Sample/Xalendar.Sample/MainPage.xaml
+++ b/src/Xalendar.Sample/Xalendar.Sample/MainPage.xaml
@@ -6,14 +6,23 @@
     xmlns:local="clr-namespace:Xalendar.Sample"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:xalendar="clr-namespace:Xalendar.View.Controls;assembly=Xalendar.View">
-    <StackLayout>
-        <xalendar:CalendarView Events="{Binding Events}" />
+    <ScrollView>
+        <StackLayout>
+            <xalendar:CalendarView Events="{Binding Events}" />
 
-        <Button
-            BackgroundColor="DodgerBlue"
-            Clicked="OnRandomButtonClick"
-            Margin="20,0"
-            Text="Add random event"
-            TextColor="White" />
-    </StackLayout>
+            <Button
+                BackgroundColor="DodgerBlue"
+                Clicked="OnRandomButtonClick"
+                Margin="20,0"
+                Text="Add random event"
+                TextColor="White" />
+
+            <Button
+                BackgroundColor="Red"
+                Clicked="OnRemoveButtonClick"
+                Margin="20,0"
+                Text="Remove event"
+                TextColor="White" />
+        </StackLayout>
+    </ScrollView>
 </ContentPage>

--- a/src/Xalendar.Sample/Xalendar.Sample/MainPage.xaml
+++ b/src/Xalendar.Sample/Xalendar.Sample/MainPage.xaml
@@ -30,6 +30,13 @@
                 Margin="20,0"
                 Text="Remove all events"
                 TextColor="White" />
+
+            <Button
+                BackgroundColor="Goldenrod"
+                Command="{Binding ReplaceEventCommand}"
+                Margin="20,0"
+                Text="Replace event"
+                TextColor="White" />
         </StackLayout>
     </ScrollView>
 </ContentPage>

--- a/src/Xalendar.Sample/Xalendar.Sample/MainPage.xaml.cs
+++ b/src/Xalendar.Sample/Xalendar.Sample/MainPage.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.ObjectModel;
+using System.Linq;
 using Xalendar.Api.Interfaces;
 using Xamarin.Forms;
 
@@ -17,6 +18,12 @@ namespace Xalendar.Sample
         {
             if (BindingContext is MainPageViewModel viewModel)
                 viewModel.AddRandomEvent();
+        }
+
+        private void OnRemoveButtonClick(object sender, EventArgs e)
+        {
+            if (BindingContext is MainPageViewModel viewModel)
+                viewModel.RemoveEvent();
         }
     }
 
@@ -43,6 +50,14 @@ namespace Xalendar.Sample
             var customEvent = new CustomEvent(_dayEventToStart, "Nome evento", eventDate, eventDate, false);
             Events.Add(customEvent);
             _dayEventToStart++;
+        }
+
+        public void RemoveEvent()
+        {
+            var firstEvent = Events.FirstOrDefault();
+
+            if (firstEvent != null)
+                Events.Remove(firstEvent);
         }
     }
 

--- a/src/Xalendar.Sample/Xalendar.Sample/MainPage.xaml.cs
+++ b/src/Xalendar.Sample/Xalendar.Sample/MainPage.xaml.cs
@@ -46,10 +46,14 @@ namespace Xalendar.Sample
         
         public void AddRandomEvent()
         {
-            var eventDate = new DateTime(2020, 9, _dayEventToStart);
-            var customEvent = new CustomEvent(_dayEventToStart, "Nome evento", eventDate, eventDate, false);
-            Events.Add(customEvent);
-            _dayEventToStart++;
+            try
+            {
+                var eventDate = new DateTime(2020, 9, _dayEventToStart);
+                var customEvent = new CustomEvent(_dayEventToStart, "Nome evento", eventDate, eventDate, false);
+                Events.Add(customEvent);
+                _dayEventToStart++;
+            }
+            catch (Exception) { }
         }
 
         public void RemoveEvent()

--- a/src/Xalendar.Sample/Xalendar.Sample/MainPage.xaml.cs
+++ b/src/Xalendar.Sample/Xalendar.Sample/MainPage.xaml.cs
@@ -30,10 +30,14 @@ namespace Xalendar.Sample
     public class MainPageViewModel
     {
         public ObservableCollection<ICalendarViewEvent> Events { get; }
+        
+        public Command RemoveAllEventsCommand { get; }
     
         public MainPageViewModel()
         {
             Events = new ObservableCollection<ICalendarViewEvent>();
+
+            RemoveAllEventsCommand = new Command(RemoveAllEvents);
     
             for (var index = 1; index <= 10; index++)
             {
@@ -41,7 +45,9 @@ namespace Xalendar.Sample
                 Events.Add(new CustomEvent(index, "Nome evento", eventDate, eventDate, false));
             }
         }
-    
+
+        private void RemoveAllEvents() => Events.Clear();
+
         private int _dayEventToStart = 11;
         
         public void AddRandomEvent()

--- a/src/Xalendar.Sample/Xalendar.Sample/MainPage.xaml.cs
+++ b/src/Xalendar.Sample/Xalendar.Sample/MainPage.xaml.cs
@@ -32,12 +32,14 @@ namespace Xalendar.Sample
         public ObservableCollection<ICalendarViewEvent> Events { get; }
         
         public Command RemoveAllEventsCommand { get; }
+        public Command ReplaceEventCommand { get; }
     
         public MainPageViewModel()
         {
             Events = new ObservableCollection<ICalendarViewEvent>();
 
             RemoveAllEventsCommand = new Command(RemoveAllEvents);
+            ReplaceEventCommand = new Command(ReplaceEvent);
     
             for (var index = 1; index <= 10; index++)
             {
@@ -47,6 +49,18 @@ namespace Xalendar.Sample
         }
 
         private void RemoveAllEvents() => Events.Clear();
+
+        private void ReplaceEvent()
+        {
+            var firstEvent = Events.FirstOrDefault();
+            
+            if (firstEvent is null)
+                return;
+            
+            var eventDate = new DateTime(2020, 9, 24);
+            var newEvent = new CustomEvent(firstEvent.Id, firstEvent.Name, eventDate, eventDate, firstEvent.IsAllDay);
+            Events[0] = newEvent;
+        }
 
         private int _dayEventToStart = 11;
         

--- a/src/Xalendar.View/Controls/CalendarView.xaml.cs
+++ b/src/Xalendar.View/Controls/CalendarView.xaml.cs
@@ -42,17 +42,17 @@ namespace Xalendar.View.Controls
                     newEvents.CollectionChanged += OnEventsCollectionChanged;
 
                 if (newvalue is IEnumerable<ICalendarViewEvent> events)
-                    UpdateEvents(calendarView, events);
+                    AddEvents(calendarView, events);
                 
                 void OnEventsCollectionChanged(object sender, NotifyCollectionChangedEventArgs args)
                 {
                     var notifiedEvents = args.NewItems.Cast<ICalendarViewEvent>();
-                    UpdateEvents(calendarView, notifiedEvents);
+                    AddEvents(calendarView, notifiedEvents);
                 }
             }
         }
         
-        private static void UpdateEvents(CalendarView calendarView, IEnumerable<ICalendarViewEvent> events)
+        private static void AddEvents(CalendarView calendarView, IEnumerable<ICalendarViewEvent> events)
         {
             calendarView._monthContainer.AddEvents(events);
             calendarView.RecycleDays(calendarView._monthContainer.Days);

--- a/src/Xalendar.View/Controls/CalendarView.xaml.cs
+++ b/src/Xalendar.View/Controls/CalendarView.xaml.cs
@@ -46,6 +46,8 @@ namespace Xalendar.View.Controls
                 
                 void OnEventsCollectionChanged(object sender, NotifyCollectionChangedEventArgs args)
                 {
+                    System.Diagnostics.Debug.WriteLine(args.Action);
+                    
                     if (args.Action == NotifyCollectionChangedAction.Add)
                     {
                         var notifiedEvents = args.NewItems.Cast<ICalendarViewEvent>();

--- a/src/Xalendar.View/Controls/CalendarView.xaml.cs
+++ b/src/Xalendar.View/Controls/CalendarView.xaml.cs
@@ -59,6 +59,9 @@ namespace Xalendar.View.Controls
                         var notifiedEvents = args.OldItems.Cast<ICalendarViewEvent>();
                         RemoveEvents(calendarView, notifiedEvents);
                     }
+
+                    if (args.Action == NotifyCollectionChangedAction.Reset)
+                        RemoveAllEvents(calendarView);
                 }
             }
         }
@@ -74,6 +77,12 @@ namespace Xalendar.View.Controls
             foreach (var calendarViewEvent in notifiedEvents)
                 calendarView._monthContainer.RemoveEvent(calendarViewEvent);
             
+            calendarView.RecycleDays(calendarView._monthContainer.Days);
+        }
+
+        private static void RemoveAllEvents(CalendarView calendarView)
+        {
+            calendarView._monthContainer.RemoveAllEvents();
             calendarView.RecycleDays(calendarView._monthContainer.Days);
         }
 

--- a/src/Xalendar.View/Controls/CalendarView.xaml.cs
+++ b/src/Xalendar.View/Controls/CalendarView.xaml.cs
@@ -62,6 +62,13 @@ namespace Xalendar.View.Controls
 
                     if (args.Action == NotifyCollectionChangedAction.Reset)
                         RemoveAllEvents(calendarView);
+
+                    if (args.Action == NotifyCollectionChangedAction.Replace)
+                    {
+                        var oldEventsNotified = args.OldItems.Cast<ICalendarViewEvent>();
+                        var newEventsNotified = args.NewItems.Cast<ICalendarViewEvent>();
+                        ReplaceEvents(calendarView, oldEventsNotified, newEventsNotified);
+                    }
                 }
             }
         }
@@ -83,6 +90,14 @@ namespace Xalendar.View.Controls
         private static void RemoveAllEvents(CalendarView calendarView)
         {
             calendarView._monthContainer.RemoveAllEvents();
+            calendarView.RecycleDays(calendarView._monthContainer.Days);
+        }
+
+        private static void ReplaceEvents(CalendarView calendarView, IEnumerable<ICalendarViewEvent> oldEventsNotified,
+            IEnumerable<ICalendarViewEvent> newEventsNotified)
+        {
+            RemoveEvents(calendarView, oldEventsNotified);
+            AddEvents(calendarView, newEventsNotified);
             calendarView.RecycleDays(calendarView._monthContainer.Days);
         }
 

--- a/src/Xalendar.View/Controls/CalendarView.xaml.cs
+++ b/src/Xalendar.View/Controls/CalendarView.xaml.cs
@@ -51,16 +51,29 @@ namespace Xalendar.View.Controls
                         var notifiedEvents = args.NewItems.Cast<ICalendarViewEvent>();
                         AddEvents(calendarView, notifiedEvents);
                     }
+
+                    if (args.Action == NotifyCollectionChangedAction.Remove)
+                    {
+                        var notifiedEvents = args.OldItems.Cast<ICalendarViewEvent>();
+                        RemoveEvents(calendarView, notifiedEvents);
+                    }
                 }
             }
         }
-        
+
         private static void AddEvents(CalendarView calendarView, IEnumerable<ICalendarViewEvent> events)
         {
             calendarView._monthContainer.AddEvents(events);
             calendarView.RecycleDays(calendarView._monthContainer.Days);
         }
 
+        private static void RemoveEvents(CalendarView calendarView, IEnumerable<ICalendarViewEvent> notifiedEvents)
+        {
+            foreach (var calendarViewEvent in notifiedEvents)
+                calendarView._monthContainer.RemoveEvent(calendarViewEvent);
+            
+            calendarView.RecycleDays(calendarView._monthContainer.Days);
+        }
 
         private readonly MonthContainer _monthContainer;
         private readonly int _numberOfDaysInContainer;

--- a/src/Xalendar.View/Controls/CalendarView.xaml.cs
+++ b/src/Xalendar.View/Controls/CalendarView.xaml.cs
@@ -46,8 +46,11 @@ namespace Xalendar.View.Controls
                 
                 void OnEventsCollectionChanged(object sender, NotifyCollectionChangedEventArgs args)
                 {
-                    var notifiedEvents = args.NewItems.Cast<ICalendarViewEvent>();
-                    AddEvents(calendarView, notifiedEvents);
+                    if (args.Action == NotifyCollectionChangedAction.Add)
+                    {
+                        var notifiedEvents = args.NewItems.Cast<ICalendarViewEvent>();
+                        AddEvents(calendarView, notifiedEvents);
+                    }
                 }
             }
         }

--- a/src/Xalendar.View/Controls/CalendarView.xaml.cs
+++ b/src/Xalendar.View/Controls/CalendarView.xaml.cs
@@ -46,8 +46,6 @@ namespace Xalendar.View.Controls
                 
                 void OnEventsCollectionChanged(object sender, NotifyCollectionChangedEventArgs args)
                 {
-                    System.Diagnostics.Debug.WriteLine(args.Action);
-                    
                     if (args.Action == NotifyCollectionChangedAction.Add)
                     {
                         var notifiedEvents = args.NewItems.Cast<ICalendarViewEvent>();


### PR DESCRIPTION
Agora é possível remover eventos no calendário em tempo de execução. Para isso foi dado suporte as _actions_ **Remove**, **Replace** e **Reset** do **NotifyCollectionChangedAction** da **ObservableCollection**.