### PR TITLE
Custom Xaml Schema

### DIFF
--- a/src/Xalendar.Sample/Xalendar.Sample/App.xaml.cs
+++ b/src/Xalendar.Sample/Xalendar.Sample/App.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Xalendar.View;
 using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
@@ -10,6 +11,7 @@ namespace Xalendar.Sample
     {
         public App()
         {
+            XalendarView.UseSchema();
             InitializeComponent();
 
             MainPage = new NavigationPage(new MainPage());

--- a/src/Xalendar.Sample/Xalendar.Sample/MainPage.xaml
+++ b/src/Xalendar.Sample/Xalendar.Sample/MainPage.xaml
@@ -5,10 +5,10 @@
     xmlns="http://xamarin.com/schemas/2014/forms"
     xmlns:local="clr-namespace:Xalendar.Sample"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-    xmlns:xalendar="clr-namespace:Xalendar.View.Controls;assembly=Xalendar.View">
+    xmlns:xal="http://xalendar.com/schemas/xaml">
     <ScrollView>
         <StackLayout>
-            <xalendar:CalendarView Events="{Binding Events}" />
+            <xal:CalendarView Events="{Binding Events}" />
 
             <Button
                 BackgroundColor="DodgerBlue"

--- a/src/Xalendar.View/Controls/CalendarDay.xaml.cs
+++ b/src/Xalendar.View/Controls/CalendarDay.xaml.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -9,7 +9,6 @@ using Xamarin.Forms.Xaml;
 
 namespace Xalendar.View.Controls
 {
-    [XamlCompilation(XamlCompilationOptions.Compile)]
     public partial class CalendarDay : ContentView
     {
         public CalendarDay()

--- a/src/Xalendar.View/Controls/CalendarView.xaml.cs
+++ b/src/Xalendar.View/Controls/CalendarView.xaml.cs
@@ -1,5 +1,4 @@
-using System;
-using System.Collections;
+﻿using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
@@ -8,12 +7,10 @@ using Xalendar.Api.Extensions;
 using Xalendar.Api.Interfaces;
 using Xalendar.Api.Models;
 using Xamarin.Forms;
-using Xamarin.Forms.Xaml;
 using XView = Xamarin.Forms.View;
 
 namespace Xalendar.View.Controls
 {
-    [XamlCompilation(XamlCompilationOptions.Compile)]
     public partial class CalendarView : ContentView
     {
         public static BindableProperty EventsProperty =

--- a/src/Xalendar.View/Properties/AssemblyInfo.cs
+++ b/src/Xalendar.View/Properties/AssemblyInfo.cs
@@ -1,0 +1,18 @@
+﻿using Xamarin.Forms;
+using Xamarin.Forms.Internals;
+using Xamarin.Forms.Xaml;
+using Xalendar.View.Controls;
+using Xalendar.View.Converters;
+
+//Linker safe
+[assembly: Preserve(AllMembers = true)]
+
+//Custom xaml schema <see href="https://docs.microsoft.com/pt-br/xamarin/xamarin-forms/xaml/custom-namespace-schemas#defining-a-custom-namespace-schema"/>
+[assembly: XmlnsDefinition("http://xalendar.com/schemas/xaml", "Xalendar.View.Controls")]
+[assembly: XmlnsDefinition("http://xalendar.com/schemas/xaml", "Xalendar.View.Converters")]
+
+//Recommended prefix <see href="https://docs.microsoft.com/pt-br/xamarin/xamarin-forms/xaml/custom-prefix"/>
+[assembly: XmlnsPrefix("http://xalendar.com/schemas/xaml", "xal")]
+
+//Xaml compilation <see href="https://docs.microsoft.com/pt-br/xamarin/xamarin-forms/xaml/xamlc"/>
+[assembly: XamlCompilation(XamlCompilationOptions.Compile)]

--- a/src/Xalendar.View/XalendarView.cs
+++ b/src/Xalendar.View/XalendarView.cs
@@ -1,0 +1,15 @@
+﻿namespace Xalendar.View
+{
+    public static class XalendarView
+    {
+        /// <summary>
+        /// Required by the XML compiler to use the <see href="https://docs.microsoft.com/pt-br/xamarin/xamarin-forms/xaml/custom-namespace-schemas#consuming-a-custom-namespace-schema">Xalendar schema</see>
+        /// </summary>
+        /// <summary xml:lang="pt-BR">
+        /// Requerido, pelo compilador XAML, para utilizar o <see href="https://docs.microsoft.com/pt-br/xamarin/xamarin-forms/xaml/custom-namespace-schemas#consuming-a-custom-namespace-schema">schema do Xalendar</see>
+        /// </summary>
+        public static void UseSchema()
+        {
+        }
+    }
+}


### PR DESCRIPTION
## Descrição

Inclusão de um s[chema Xaml personalizado](https://docs.microsoft.com/pt-br/xamarin/xamarin-forms/xaml/custom-namespace-schemas) para o Xalendar

## Alterações

- Adicionada classe `AssemblyInfo.cs`
- Criado schema personalizado contemplando `Converters` e `Controls`
- Adicionado Atributo de sugestão de nome de assembly xaml
- Centralizado o atributo de compilação xaml em nivel de assembly
- Adicionada [classe para inicialização](https://docs.microsoft.com/pt-br/xamarin/xamarin-forms/xaml/custom-namespace-schemas#consuming-a-custom-namespace-schema) do schema personalizado

## Demonstração

Agora quem for utilizar o Xalendar pode optar por incluir da forma tradicional (adicionando alias para cada namespace)

```xml
xmlns:xalendar="clr-namespace:Xalendar.View.Controls;assembly=Xalendar.View"
xmlns:xalendarConv="clr-namespace:Xalendar.View.Converters;assembly=Xalendar.View">
    <ScrollView>
        <StackLayout>
            <xalendar:CalendarView Events="{Binding Events}" />
```

ou utilizar o schema personalizado (que ja contempla todos os namespaces do inclusos)


```xml
xmlns:xal="http://xalendar.com/schemas/xaml">
    <ScrollView>
        <StackLayout>
            <xal:CalendarView Events="{Binding Events}" />
```

> Importante: Esse ultimo requer uma [classe de inicialização](https://docs.microsoft.com/pt-br/xamarin/xamarin-forms/xaml/custom-namespace-schemas#consuming-a-custom-namespace-schema) (nem que seja fake) para o compilador XAML reconhecer o assembly

- Pode se inicializar no app

``` C#
        public App()
        {
            XalendarView.UseSchema();
            InitializeComponent();
```

- Pode se inicializar apenas na pagina que utiliza o schema

``` C#
        public MainPage()
        {
            XalendarView.UseSchema();
            InitializeComponent();
```