### PR TITLE
Testes no CalendarView usando Xamarin.Forms.Mocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # My gitignore configs
 .DS_Store
-src/Xalendar.Api.Tests/coverage.opencover.xml
+src/*.Tests/coverage.opencover.xml
 src/Xalendar.Sample/Xalendar.Sample.Android/Resources/Resource.designer.cs
 src/.idea/
 

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 src/*.Tests/coverage.opencover.xml
 src/Xalendar.Sample/Xalendar.Sample.Android/Resources/Resource.designer.cs
 src/.idea/
+coverage/
 
 # Created by https://www.gitignore.io/api/dotnetcore,visualstudio
 # Edit at https://www.gitignore.io/?templates=dotnetcore,visualstudio

--- a/src/Xalendar.View.Tests/BaseTests.cs
+++ b/src/Xalendar.View.Tests/BaseTests.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Xalendar.View.Tests
+{
+    public abstract class BaseTests
+    {
+        protected TaskCompletionSource<TResult> CreateTaskCompletionSource<TResult>()
+        {
+            var taskCompletionSource = new TaskCompletionSource<TResult>();
+            var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            cancellationTokenSource.Token.Register(() => taskCompletionSource.TrySetCanceled(),
+                useSynchronizationContext: false);
+            return taskCompletionSource;
+        }
+    }
+}

--- a/src/Xalendar.View.Tests/BaseTests.cs
+++ b/src/Xalendar.View.Tests/BaseTests.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Xalendar.Api.Interfaces;
 
 namespace Xalendar.View.Tests
 {
@@ -13,6 +15,34 @@ namespace Xalendar.View.Tests
             cancellationTokenSource.Token.Register(() => taskCompletionSource.TrySetCanceled(),
                 useSynchronizationContext: false);
             return taskCompletionSource;
+        }
+        
+        protected List<ICalendarViewEvent> GenerateEvents()
+        {
+            return new List<ICalendarViewEvent>
+            {
+                new MyEvent(1, "Event name", DateTime.Now, DateTime.Now, false),
+                new MyEvent(2, "Event name", DateTime.Now, DateTime.Now, false),
+                new MyEvent(3, "Event name", DateTime.Now, DateTime.Now, false)
+            };
+        }
+    }
+
+    internal class MyEvent : ICalendarViewEvent
+    {
+        public object Id { get; }
+        public string Name { get; }
+        public DateTime StartDateTime { get; }
+        public DateTime EndDateTime { get; }
+        public bool IsAllDay { get; }
+
+        public MyEvent(object id, string name, DateTime startDateTime, DateTime endDateTime, bool isAllDay)
+        {
+            Id = id;
+            Name = name;
+            StartDateTime = startDateTime;
+            EndDateTime = endDateTime;
+            IsAllDay = isAllDay;
         }
     }
 }

--- a/src/Xalendar.View.Tests/BaseTests.cs
+++ b/src/Xalendar.View.Tests/BaseTests.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Xalendar.Api.Interfaces;
+using Xalendar.View.Controls;
+using Xamarin.Forms;
 
 namespace Xalendar.View.Tests
 {
@@ -17,14 +20,33 @@ namespace Xalendar.View.Tests
             return taskCompletionSource;
         }
         
-        protected List<ICalendarViewEvent> GenerateEvents()
+        protected List<ICalendarViewEvent> GenerateEvents(int dayOfTheEvent)
         {
+            var today = DateTime.Today;
+            
             return new List<ICalendarViewEvent>
             {
-                new MyEvent(1, "Event name", DateTime.Now, DateTime.Now, false),
-                new MyEvent(2, "Event name", DateTime.Now, DateTime.Now, false),
-                new MyEvent(3, "Event name", DateTime.Now, DateTime.Now, false)
+                new MyEvent(1, "Event name", new DateTime(today.Year, today.Month, dayOfTheEvent), new DateTime(today.Year, today.Month, 1), false)
             };
+        }
+
+        protected CalendarDay FindCalendarDayByNumber(CalendarView calendarView, string number)
+        {
+            var calendarDaysContainer = calendarView.FindByName<FlexLayout>("CalendarDaysContainer");
+            
+            return (CalendarDay) calendarDaysContainer.Children.First(calendarDay =>
+            {
+                if (calendarDay is {})
+                {
+                    if (calendarDay.FindByName<Label>("DayElement") is {} dayElement)
+                    {
+                        if (dayElement.Text == number)
+                            return true;
+                    }
+                }
+
+                return false;
+            });
         }
     }
 

--- a/src/Xalendar.View.Tests/Controls/CalendarViewTests.cs
+++ b/src/Xalendar.View.Tests/Controls/CalendarViewTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using Xalendar.View.Controls;
@@ -7,7 +8,7 @@ using Xamarin.Forms;
 namespace Xalendar.View.Tests.Controls
 {
     [TestFixture]
-    public class CalendarViewTests
+    public class CalendarViewTests : BaseTests
     {
         private CalendarView _calendarView;
         
@@ -19,33 +20,31 @@ namespace Xalendar.View.Tests.Controls
         }
 
         [Test]
-        public void ShouldChangeMonthNameWhenPreviousButtonClicked()
+        public async Task ShouldChangeMonthNameWhenPreviousButtonClicked()
         {
             var button = _calendarView.FindByName<Button>("PreviousButton");
             var monthName = _calendarView.FindByName<Label>("MonthName");
-
-            _calendarView.MonthChanged += _ =>
-            {
-                var previousMonth = DateTime.Today.AddMonths(-1);
-                Assert.AreEqual(previousMonth.ToString("MMMM yyyy"), monthName.Text);
-            };
+            var previousMonth = DateTime.Today.AddMonths(-1);
+            var taskCompletionSource = CreateTaskCompletionSource<string>();
+            _calendarView.MonthChanged += _ => taskCompletionSource.SetResult(monthName.Text);
             
             button.SendClicked();
+            
+            Assert.AreEqual(previousMonth.ToString("MMMM yyyy"), await taskCompletionSource.Task);
         }
 
         [Test]
-        public void ShouldChangeMonthNameWhenNextButtonClicked()
+        public async Task ShouldChangeMonthNameWhenNextButtonClicked()
         {
             var button = _calendarView.FindByName<Button>("NextButton");
             var monthName = _calendarView.FindByName<Label>("MonthName");
-
-            _calendarView.MonthChanged += _ =>
-            {
-                var nextMonth = DateTime.Today.AddMonths(1);
-                Assert.AreEqual(nextMonth.ToString("MMMM yyyy"), monthName.Text);
-            };
+            var nextMonth = DateTime.Today.AddMonths(1);
+            var taskCompletionSource = CreateTaskCompletionSource<string>();
+            _calendarView.MonthChanged += _ => taskCompletionSource.SetResult(monthName.Text);
             
             button.SendClicked();
+
+            Assert.AreEqual(nextMonth.ToString("MMMM yyyy"), await taskCompletionSource.Task);
         }
     }
 }

--- a/src/Xalendar.View.Tests/Controls/CalendarViewTests.cs
+++ b/src/Xalendar.View.Tests/Controls/CalendarViewTests.cs
@@ -1,7 +1,9 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
+using Xalendar.Api.Interfaces;
 using Xalendar.View.Controls;
 using Xamarin.Forms;
 
@@ -45,6 +47,16 @@ namespace Xalendar.View.Tests.Controls
             button.SendClicked();
 
             Assert.AreEqual(nextMonth.ToString("MMMM yyyy"), await taskCompletionSource.Task);
+        }
+
+        [Test]
+        public void ShouldBeCreateEventsInCalendarView()
+        {
+            var eventsBinding = new Binding {Source = GenerateEvents()};
+            
+            _calendarView.SetBinding(CalendarView.EventsProperty, eventsBinding);
+            
+            Assert.IsNotEmpty(_calendarView.Events);
         }
     }
 }

--- a/src/Xalendar.View.Tests/Controls/CalendarViewTests.cs
+++ b/src/Xalendar.View.Tests/Controls/CalendarViewTests.cs
@@ -32,5 +32,20 @@ namespace Xalendar.View.Tests.Controls
             
             button.SendClicked();
         }
+
+        [Test]
+        public void ShouldChangeMonthNameWhenNextButtonClicked()
+        {
+            var button = _calendarView.FindByName<Button>("NextButton");
+            var monthName = _calendarView.FindByName<Label>("MonthName");
+
+            _calendarView.MonthChanged += _ =>
+            {
+                var nextMonth = DateTime.Today.AddMonths(1);
+                Assert.AreEqual(nextMonth.ToString("MMMM yyyy"), monthName.Text);
+            };
+            
+            button.SendClicked();
+        }
     }
 }

--- a/src/Xalendar.View.Tests/Controls/CalendarViewTests.cs
+++ b/src/Xalendar.View.Tests/Controls/CalendarViewTests.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using NUnit.Framework;
+using Xalendar.View.Controls;
+using Xamarin.Forms;
+
+namespace Xalendar.View.Tests.Controls
+{
+    [TestFixture]
+    public class CalendarViewTests
+    {
+        private CalendarView _calendarView;
+        
+        [SetUp]
+        public void SetUp()
+        {
+            Xamarin.Forms.Mocks.MockForms.Init();
+            _calendarView = new CalendarView();
+        }
+
+        [Test]
+        public void ShouldNavigateToPreviousMonthWhenPreviousButtonClick()
+        {
+            var button = _calendarView.FindByName<Button>("PreviousButton");
+            var monthName = _calendarView.FindByName<Label>("MonthName");
+            
+            button.SendClicked();
+
+            var previousMonth = DateTime.Today.AddMonths(-1);
+            Assert.AreEqual(previousMonth.ToString("MMMM yyyy"), monthName.Text);
+        }
+    }
+}

--- a/src/Xalendar.View.Tests/Controls/CalendarViewTests.cs
+++ b/src/Xalendar.View.Tests/Controls/CalendarViewTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using NUnit.Framework;
 using Xalendar.View.Controls;
 using Xamarin.Forms;
@@ -18,15 +19,18 @@ namespace Xalendar.View.Tests.Controls
         }
 
         [Test]
-        public void ShouldNavigateToPreviousMonthWhenPreviousButtonClick()
+        public void ShouldChangeMonthNameWhenPreviousButtonClicked()
         {
             var button = _calendarView.FindByName<Button>("PreviousButton");
             var monthName = _calendarView.FindByName<Label>("MonthName");
+
+            _calendarView.MonthChanged += _ =>
+            {
+                var previousMonth = DateTime.Today.AddMonths(-1);
+                Assert.AreEqual(previousMonth.ToString("MMMM yyyy"), monthName.Text);
+            };
             
             button.SendClicked();
-
-            var previousMonth = DateTime.Today.AddMonths(-1);
-            Assert.AreEqual(previousMonth.ToString("MMMM yyyy"), monthName.Text);
         }
     }
 }

--- a/src/Xalendar.View.Tests/Controls/CalendarViewTests.cs
+++ b/src/Xalendar.View.Tests/Controls/CalendarViewTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
@@ -50,13 +51,15 @@ namespace Xalendar.View.Tests.Controls
         }
 
         [Test]
-        public void ShouldBeCreateEventsInCalendarView()
+        public void ShouldCreateIndicatorOfEvent()
         {
-            var eventsBinding = new Binding {Source = GenerateEvents()};
+            var dayOfTheEvent = 1;
+            var events = GenerateEvents(dayOfTheEvent);
             
-            _calendarView.SetBinding(CalendarView.EventsProperty, eventsBinding);
+            _calendarView.Events = events;
             
-            Assert.IsNotEmpty(_calendarView.Events);
+            var calendarDay = FindCalendarDayByNumber(_calendarView, dayOfTheEvent.ToString());
+            Assert.IsTrue(calendarDay.FindByName<BoxView>("HasEventsElement").IsVisible);
         }
     }
 }

--- a/src/Xalendar.View.Tests/Xalendar.View.Tests.csproj
+++ b/src/Xalendar.View.Tests/Xalendar.View.Tests.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="Xamarin.Forms.Mocks" Version="3.5.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Xalendar.View/Controls/CalendarView.xaml
+++ b/src/Xalendar.View/Controls/CalendarView.xaml
@@ -18,7 +18,10 @@
             AlignItems="Center"
             HeightRequest="56"
             Padding="10,0">
-            <Button Clicked="OnPreviousMonthClick" Text="◀" />
+            <Button
+                Clicked="OnPreviousMonthClick"
+                Text="◀"
+                x:Name="PreviousButton" />
 
             <Label
                 FlexLayout.Grow="1"

--- a/src/Xalendar.View/Controls/CalendarView.xaml
+++ b/src/Xalendar.View/Controls/CalendarView.xaml
@@ -29,7 +29,10 @@
                 HorizontalTextAlignment="Center"
                 x:Name="MonthName" />
 
-            <Button Clicked="OnNextMonthClick" Text="▶" />
+            <Button
+                Clicked="OnNextMonthClick"
+                Text="▶"
+                x:Name="NextButton" />
         </FlexLayout>
 
         <FlexLayout Wrap="Wrap" x:Name="CalendarDaysOfWeekContainer">


### PR DESCRIPTION
Esta PR tem como objetivo inserir alguns testes no CalendarView usando o Xamarin.Forms.Mocks. Entendo que o ideal seria utilizamos testes de UI, mas para isso, precisaríamos manter uma suite destes testes que seria paga, então, neste primeiro momento, optei por tentar usar a biblioteca de mock.

Inicialmente implementei apenas o teste para validar se o nome do mês é alterado quando navegamos entre os meses, clicando nos botões anterior e próximo. ~~A única coisa que não gostei dos testes é que, como não temos um controle para saber quando o evento do botão foi totalmente finalizado, a asserção do teste ocorria antes do método que o CalendarView assina ser executado, o que fazia o teste falhar. Então, usei o evento `MonthChanged` e inserir a asserção dentro dele, o que fere a ordem do **AAA** dos testes mas fez os testes passarem.~~ Para testar os cliques de botões que dependem de uma operação ser executada para depois validar o resultado, utilizei `TaskCompletionSource` assinando eventos e atribuindo o resultado. Desta forma foi possível aguardar estes resultados serem atribuídos para fazer a asserção no teste.

Sugestões para melhorar isso são bem vindas.