### PR TITLE
Adiciona suporte a customização do dia inicial da semana na API

### DIFF
--- a/src/Xalendar.Api.Tests/Models/MonthContainerTests.cs
+++ b/src/Xalendar.Api.Tests/Models/MonthContainerTests.cs
@@ -120,6 +120,30 @@ namespace Xalendar.Api.Tests.Models
         };
 
         [Test]
+        [TestCaseSource(nameof(ValuesForDaysOfWeekShouldStartWithSpecificDay))]
+        public void DaysOfWeekShouldStartWithSpecificDay(string language, DayOfWeek firstDayOfWeek, List<string> expectedDaysOfWeek)
+        {
+            CultureInfo.CurrentCulture = new CultureInfo(language);
+            var dateTime = DateTime.Today;
+            var monthContainer = new MonthContainer(dateTime);
+
+            var daysOfWeek = monthContainer.DaysOfWeek;
+
+            CollectionAssert.AreEqual(expectedDaysOfWeek, daysOfWeek.ToList());
+        }
+
+        private static object[] ValuesForDaysOfWeekShouldStartWithSpecificDay =
+        {
+            new object[] { "en-US", DayOfWeek.Sunday, new List<string> { "SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT" } },
+            new object[] { "en-US", DayOfWeek.Monday, new List<string> { "MON", "TUE", "WED", "THU", "FRI", "SAT", "SUN" } },
+            new object[] { "en-US", DayOfWeek.Tuesday, new List<string> { "TUE", "WED", "THU", "FRI", "SAT", "SUN", "MON" } },
+            new object[] { "en-US", DayOfWeek.Wednesday, new List<string> { "WED", "THU", "FRI", "SAT", "SUN", "MON", "TUE" } },
+            new object[] { "en-US", DayOfWeek.Thursday, new List<string> { "THU", "FRI", "SAT", "SUN", "MON", "TUE", "WED" } },
+            new object[] { "en-US", DayOfWeek.Friday, new List<string> { "FRI", "SAT", "SUN", "MON", "TUE", "WED", "THU" } },
+            new object[] { "en-US", DayOfWeek.Saturday, new List<string> { "SAT", "SUN", "MON", "TUE", "WED", "THU", "FRI" } }
+        };
+
+        [Test]
         public void EventsShouldBeRemovedFromMonthContainer()
         {
             var dateTime = new DateTime(2020, 7, 9);

--- a/src/Xalendar.Api.Tests/Models/MonthContainerTests.cs
+++ b/src/Xalendar.Api.Tests/Models/MonthContainerTests.cs
@@ -125,7 +125,7 @@ namespace Xalendar.Api.Tests.Models
         {
             CultureInfo.CurrentCulture = new CultureInfo(language);
             var dateTime = DateTime.Today;
-            var monthContainer = new MonthContainer(dateTime);
+            var monthContainer = new MonthContainer(dateTime, firstDayOfWeek);
 
             var daysOfWeek = monthContainer.DaysOfWeek;
 

--- a/src/Xalendar.Api.Tests/Models/MonthContainerTests.cs
+++ b/src/Xalendar.Api.Tests/Models/MonthContainerTests.cs
@@ -220,10 +220,10 @@ namespace Xalendar.Api.Tests.Models
             new object[] { new DateTime(2020, 9, 1), DayOfWeek.Sunday, GenerateDaysOfSeptember2020(2, 3) },
             new object[] { new DateTime(2020, 9, 1), DayOfWeek.Monday, GenerateDaysOfSeptember2020(1, 4) },
             new object[] { new DateTime(2020, 9, 1), DayOfWeek.Tuesday, GenerateDaysOfSeptember2020(0, 5) },
-            new object[] { new DateTime(2020, 9, 1), DayOfWeek.Wednesday, GenerateDaysOfSeptember2020(0, 5) },
-            new object[] { new DateTime(2020, 9, 1), DayOfWeek.Thursday, GenerateDaysOfSeptember2020(0, 5) },
-            new object[] { new DateTime(2020, 9, 1), DayOfWeek.Friday, GenerateDaysOfSeptember2020(0, 5) },
-            new object[] { new DateTime(2020, 9, 1), DayOfWeek.Saturday, GenerateDaysOfSeptember2020(0, 5) }
+            new object[] { new DateTime(2020, 9, 1), DayOfWeek.Wednesday, GenerateDaysOfSeptember2020(6, 6) },
+            new object[] { new DateTime(2020, 9, 1), DayOfWeek.Thursday, GenerateDaysOfSeptember2020(5, 7) },
+            new object[] { new DateTime(2020, 9, 1), DayOfWeek.Friday, GenerateDaysOfSeptember2020(4, 1) },
+            new object[] { new DateTime(2020, 9, 1), DayOfWeek.Saturday, GenerateDaysOfSeptember2020(3, 2) }
         };
 
         private static List<Day?> GenerateDaysOfSeptember2020(int daysToDiscardAtStart, int daysToDiscardAtEnd)

--- a/src/Xalendar.Api.Tests/Models/MonthContainerTests.cs
+++ b/src/Xalendar.Api.Tests/Models/MonthContainerTests.cs
@@ -203,5 +203,51 @@ namespace Xalendar.Api.Tests.Models
             
             Assert.AreEqual(new DateTime(2020, 10, 31, 23, 59, 59), lastDay);
         }
+
+        [Test]
+        [TestCaseSource(nameof(ValuesForDaysOfMonthShouldStartBasedOnFirstDayOfWeek))]
+        public void DaysOfMonthShouldStartBasedOnFirstDayOfWeek(DateTime dateTime, DayOfWeek firstDayOfWeek, List<Day?> expectedDays)
+        {
+            var monthContainer = new MonthContainer(dateTime, firstDayOfWeek);
+
+            var days = monthContainer.Days;
+            
+            CollectionAssert.AreEqual(expectedDays, days);
+        }
+
+        private static object[] ValuesForDaysOfMonthShouldStartBasedOnFirstDayOfWeek =
+        {
+            new object[] { new DateTime(2020, 9, 1), DayOfWeek.Sunday, GenerateDaysOfSeptember2020(2, 3) },
+            new object[] { new DateTime(2020, 9, 1), DayOfWeek.Monday, GenerateDaysOfSeptember2020(1, 4) },
+            new object[] { new DateTime(2020, 9, 1), DayOfWeek.Tuesday, GenerateDaysOfSeptember2020(0, 5) },
+            new object[] { new DateTime(2020, 9, 1), DayOfWeek.Wednesday, GenerateDaysOfSeptember2020(0, 5) },
+            new object[] { new DateTime(2020, 9, 1), DayOfWeek.Thursday, GenerateDaysOfSeptember2020(0, 5) },
+            new object[] { new DateTime(2020, 9, 1), DayOfWeek.Friday, GenerateDaysOfSeptember2020(0, 5) },
+            new object[] { new DateTime(2020, 9, 1), DayOfWeek.Saturday, GenerateDaysOfSeptember2020(0, 5) }
+        };
+
+        private static List<Day?> GenerateDaysOfSeptember2020(int daysToDiscardAtStart, int daysToDiscardAtEnd)
+        {
+            var days = new List<Day?>();
+            
+            for (var index = 0; index < daysToDiscardAtStart; index++)
+                days.Add(default(Day));
+
+            var dateTime = new DateTime(2020, 9, 1);
+            for (var index = 1; index <= 30; index++)
+            {
+                days.Add(new Day(dateTime));
+                dateTime = dateTime.AddDays(1);
+            }
+            
+            for (var index = 0; index < daysToDiscardAtEnd; index++)
+                days.Add(default(Day));
+            
+            if (days.Count < 42)
+                for (var index = days.Count; index < 42; index++)
+                    days.Add(default(Day));
+            
+            return days;
+        }
     }
 }

--- a/src/Xalendar.Api/Extensions/MonthContainerExtension.cs
+++ b/src/Xalendar.Api/Extensions/MonthContainerExtension.cs
@@ -18,27 +18,5 @@ namespace Xalendar.Api.Extensions
             monthContainer._month.RemoveAllEvents();
         
         public static string GetName(this MonthContainer monthContainer) => monthContainer._month.MonthDateTime.ToString("MMMM yyyy");
-        
-        internal static void GetDaysToDiscardAtStartOfMonth(this MonthContainer monthContainer, List<Day?> daysOfContainer)
-        {
-            var firstDay = monthContainer._month.Days.First();
-            var numberOfDaysToDiscard = (int) firstDay!.DateTime.DayOfWeek;
-            
-            for (var index = 0; index < numberOfDaysToDiscard; index++)
-                daysOfContainer.Add(default(Day));
-        }
-        
-        internal static void GetDaysToDiscardAtEndOfMonth(this MonthContainer monthContainer, List<Day?> daysOfContainer)
-        {
-            var lastDay = monthContainer._month.Days.Last();
-            var numberOfDaysToDiscard = 6 - (int) lastDay.DateTime.DayOfWeek;
-            
-            for (var index = 0; index < numberOfDaysToDiscard; index++)
-                daysOfContainer.Add(default(Day));
-
-            if (daysOfContainer.Count < 42)
-                for (var index = daysOfContainer.Count; index < 42; index++)
-                    daysOfContainer.Add(default(Day));
-        }
     }
 }

--- a/src/Xalendar.Api/Models/MonthContainer.cs
+++ b/src/Xalendar.Api/Models/MonthContainer.cs
@@ -20,9 +20,12 @@ namespace Xalendar.Api.Models
 
         public DateTime LastDay => Days.Last(day => day is {})!.DateTime.AddHours(23).AddMinutes(59).AddSeconds(59);
 
+        private DayOfWeek _firstDayOfWeek;
+        
         public MonthContainer(DateTime dateTime, DayOfWeek firstDayOfWeek = DayOfWeek.Sunday)
         {
             _month = new Month(dateTime);
+            _firstDayOfWeek = firstDayOfWeek;
 
             DaysOfWeek = GenerateDaysOfWeek(firstDayOfWeek)
                 .Select(GetDayOfWeekAbbreviated)

--- a/src/Xalendar.Api/Models/MonthContainer.cs
+++ b/src/Xalendar.Api/Models/MonthContainer.cs
@@ -60,6 +60,28 @@ namespace Xalendar.Api.Models
             return daysOfContainer;
         }
         
+        private void GetDaysToDiscardAtStartOfMonth(List<Day?> daysOfContainer)
+        {
+            var firstDay = _month.Days.First();
+            var numberOfDaysToDiscard = (int) firstDay!.DateTime.DayOfWeek;
+            
+            for (var index = 0; index < numberOfDaysToDiscard; index++)
+                daysOfContainer.Add(default(Day));
+        }
+        
+        private void GetDaysToDiscardAtEndOfMonth(List<Day?> daysOfContainer)
+        {
+            var lastDay = _month.Days.Last();
+            var numberOfDaysToDiscard = 6 - (int) lastDay.DateTime.DayOfWeek;
+            
+            for (var index = 0; index < numberOfDaysToDiscard; index++)
+                daysOfContainer.Add(default(Day));
+
+            if (daysOfContainer.Count < 42)
+                for (var index = daysOfContainer.Count; index < 42; index++)
+                    daysOfContainer.Add(default(Day));
+        }
+        
         public void Next()
         {
             var nextDateTime = _month.MonthDateTime.AddMonths(1);

--- a/src/Xalendar.Api/Models/MonthContainer.cs
+++ b/src/Xalendar.Api/Models/MonthContainer.cs
@@ -63,7 +63,8 @@ namespace Xalendar.Api.Models
         private void GetDaysToDiscardAtStartOfMonth(List<Day?> daysOfContainer)
         {
             var firstDay = _month.Days.First();
-            var numberOfDaysToDiscard = (int) firstDay!.DateTime.DayOfWeek;
+            var differenceOfDays = ((int)_firstDayOfWeek - (int) firstDay!.DateTime.DayOfWeek);
+            var numberOfDaysToDiscard = differenceOfDays <= 0 ? Math.Abs(differenceOfDays) : 7 - differenceOfDays;  
             
             for (var index = 0; index < numberOfDaysToDiscard; index++)
                 daysOfContainer.Add(default(Day));
@@ -71,12 +72,6 @@ namespace Xalendar.Api.Models
         
         private void GetDaysToDiscardAtEndOfMonth(List<Day?> daysOfContainer)
         {
-            var lastDay = _month.Days.Last();
-            var numberOfDaysToDiscard = 6 - (int) lastDay.DateTime.DayOfWeek;
-            
-            for (var index = 0; index < numberOfDaysToDiscard; index++)
-                daysOfContainer.Add(default(Day));
-
             if (daysOfContainer.Count < 42)
                 for (var index = daysOfContainer.Count; index < 42; index++)
                     daysOfContainer.Add(default(Day));

--- a/src/Xalendar.Api/Models/MonthContainer.cs
+++ b/src/Xalendar.Api/Models/MonthContainer.cs
@@ -24,9 +24,22 @@ namespace Xalendar.Api.Models
         {
             _month = new Month(dateTime);
 
-            DaysOfWeek = Enum.GetValues(typeof(DayOfWeek)).Cast<DayOfWeek>()
+            DaysOfWeek = GenerateDaysOfWeek(firstDayOfWeek)
                 .Select(GetDayOfWeekAbbreviated)
                 .ToList();
+        }
+
+        private IEnumerable<DayOfWeek> GenerateDaysOfWeek(DayOfWeek firstDayOfWeek)
+        {
+            var daysOfWeek = new List<DayOfWeek>();
+
+            for (var index = (int)firstDayOfWeek; index <= 6; index++)
+                daysOfWeek.Add((DayOfWeek)index);
+            
+            for (var index = 0; index < (int)firstDayOfWeek; index++)
+                daysOfWeek.Add((DayOfWeek)index);
+
+            return daysOfWeek;
         }
 
         private string GetDayOfWeekAbbreviated(DayOfWeek dayOfWeek)

--- a/src/Xalendar.Api/Models/MonthContainer.cs
+++ b/src/Xalendar.Api/Models/MonthContainer.cs
@@ -20,7 +20,7 @@ namespace Xalendar.Api.Models
 
         public DateTime LastDay => Days.Last(day => day is {})!.DateTime.AddHours(23).AddMinutes(59).AddSeconds(59);
 
-        public MonthContainer(DateTime dateTime)
+        public MonthContainer(DateTime dateTime, DayOfWeek firstDayOfWeek = DayOfWeek.Sunday)
         {
             _month = new Month(dateTime);
 


### PR DESCRIPTION
Esta PR possibilita customizar a construção do MonthContainer para informar o parâmetro do dia inicial que a semana deve começar.

Este suporte está apenas no projeto da API. Em futura PR virá o suporte no projeto da view onde existirá uma bindable property para customizarmos esse valor no controle.