### PR TITLE
Add day selected event in CalendarView

### DIFF
--- a/src/Xalendar.Sample/Xalendar.Sample/Converters/IntToBooleanConverter.cs
+++ b/src/Xalendar.Sample/Xalendar.Sample/Converters/IntToBooleanConverter.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Globalization;
+using Xamarin.Forms;
+
+namespace Xalendar.Sample.Converters
+{
+    public class IntToBooleanConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is int intValue)
+                return intValue > 0 ? true : false;
+
+            return false;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Xalendar.Sample/Xalendar.Sample/Services/EventService.cs
+++ b/src/Xalendar.Sample/Xalendar.Sample/Services/EventService.cs
@@ -21,42 +21,42 @@ namespace Xalendar.Sample.Services
             {
                 var dateTime = DateTime.Today;
                 var eventDate = new DateTime(dateTime.Year, dateTime.Month, index);
-                _events.Add(new CustomEvent(index, "Nome evento", eventDate, eventDate, false));
+                _events.Add(new CustomEvent(index, $"Evento {index}", eventDate, eventDate, false));
             }
             
             for (var index = 3; index <= 8; index++)
             {
                 var dateTime = DateTime.Today.AddMonths(1);
                 var eventDate = new DateTime(dateTime.Year, dateTime.Month, index);
-                _events.Add(new CustomEvent(index, "Nome evento", eventDate, eventDate, false));
+                _events.Add(new CustomEvent(index, $"Evento {index}", eventDate, eventDate, false));
             }
             
             for (var index = 5; index <= 9; index++)
             {
                 var dateTime = DateTime.Today.AddMonths(2);
                 var eventDate = new DateTime(dateTime.Year, dateTime.Month, index);
-                _events.Add(new CustomEvent(index, "Nome evento", eventDate, eventDate, false));
+                _events.Add(new CustomEvent(index, $"Evento {index}", eventDate, eventDate, false));
             }
             
             for (var index = 15; index <= 16; index++)
             {
                 var dateTime = DateTime.Today.AddMonths(3);
                 var eventDate = new DateTime(dateTime.Year, dateTime.Month, index);
-                _events.Add(new CustomEvent(index, "Nome evento", eventDate, eventDate, false));
+                _events.Add(new CustomEvent(index, $"Evento {index}", eventDate, eventDate, false));
             }
             
             for (var index = 6; index <= 10; index++)
             {
                 var dateTime = DateTime.Today.AddMonths(-1);
                 var eventDate = new DateTime(dateTime.Year, dateTime.Month, index);
-                _events.Add(new CustomEvent(index, "Nome evento", eventDate, eventDate, false));
+                _events.Add(new CustomEvent(index, $"Evento {index}", eventDate, eventDate, false));
             }
             
             for (var index = 2; index <= 5; index++)
             {
                 var dateTime = DateTime.Today.AddMonths(-2);
                 var eventDate = new DateTime(dateTime.Year, dateTime.Month, index);
-                _events.Add(new CustomEvent(index, "Nome evento", eventDate, eventDate, false));
+                _events.Add(new CustomEvent(index, $"Evento {index}", eventDate, eventDate, false));
             }
         }
 

--- a/src/Xalendar.Sample/Xalendar.Sample/ViewModels/MainPageViewModel.cs
+++ b/src/Xalendar.Sample/Xalendar.Sample/ViewModels/MainPageViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using Xalendar.Api.Interfaces;
@@ -11,6 +12,7 @@ namespace Xalendar.Sample.ViewModels
     public class MainPageViewModel
     {
         public ObservableCollection<ICalendarViewEvent> Events { get; }
+        public ObservableCollection<ICalendarViewEvent> EventsOfDay { get; }
         
         public Command RemoveAllEventsCommand { get; }
         public Command ReplaceEventCommand { get; }
@@ -18,6 +20,7 @@ namespace Xalendar.Sample.ViewModels
         public MainPageViewModel()
         {
             Events = new ObservableCollection<ICalendarViewEvent>();
+            EventsOfDay = new ObservableCollection<ICalendarViewEvent>();
 
             RemoveAllEventsCommand = new Command(RemoveAllEvents);
             ReplaceEventCommand = new Command(ReplaceEvent);
@@ -65,6 +68,14 @@ namespace Xalendar.Sample.ViewModels
             
             foreach (var customEvent in EventService.Instance.GetEventsByRange(start, end))
                 Events.Add(customEvent);
+        }
+
+        public void AddEventsOfDay(IEnumerable<ICalendarViewEvent> events)
+        {
+            EventsOfDay.Clear();
+            
+            foreach (var calendarEvent in events)
+                EventsOfDay.Add(calendarEvent);
         }
     }
 }

--- a/src/Xalendar.Sample/Xalendar.Sample/Views/MainPage.xaml
+++ b/src/Xalendar.Sample/Xalendar.Sample/Views/MainPage.xaml
@@ -9,6 +9,7 @@
     <ScrollView>
         <StackLayout>
             <xal:CalendarView
+                DaySelected="OnDaySelected"
                 Events="{Binding Events}"
                 FirstDayOfWeek="Monday"
                 MonthChanged="OnMonthChanged" />

--- a/src/Xalendar.Sample/Xalendar.Sample/Views/MainPage.xaml
+++ b/src/Xalendar.Sample/Xalendar.Sample/Views/MainPage.xaml
@@ -3,9 +3,16 @@
     Title="CalendarView Sample"
     x:Class="Xalendar.Sample.Views.MainPage"
     xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:converters="clr-namespace:Xalendar.Sample.Converters"
     xmlns:local="clr-namespace:Xalendar.Sample.Views"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:xal="http://xalendar.com/schemas/xaml">
+    <ContentPage.Resources>
+        <ResourceDictionary>
+            <converters:IntToBooleanConverter x:Key="IntToBooleanConverter" />
+        </ResourceDictionary>
+    </ContentPage.Resources>
+
     <ScrollView>
         <StackLayout>
             <xal:CalendarView
@@ -13,6 +20,18 @@
                 Events="{Binding Events}"
                 FirstDayOfWeek="Monday"
                 MonthChanged="OnMonthChanged" />
+
+            <ListView
+                Footer=""
+                HeightRequest="140"
+                IsVisible="{Binding EventsOfDay.Count, Converter={StaticResource IntToBooleanConverter}}"
+                ItemsSource="{Binding EventsOfDay}">
+                <ListView.ItemTemplate>
+                    <DataTemplate>
+                        <TextCell Text="{Binding Name}" />
+                    </DataTemplate>
+                </ListView.ItemTemplate>
+            </ListView>
 
             <Button
                 BackgroundColor="DodgerBlue"

--- a/src/Xalendar.Sample/Xalendar.Sample/Views/MainPage.xaml.cs
+++ b/src/Xalendar.Sample/Xalendar.Sample/Views/MainPage.xaml.cs
@@ -33,5 +33,10 @@ namespace Xalendar.Sample.Views
             if (BindingContext is MainPageViewModel viewModel)
                 viewModel.GetEventsByRange(args.Start, args.End);
         }
+
+        private void OnDaySelected(object obj)
+        {
+            
+        }
     }
 }

--- a/src/Xalendar.Sample/Xalendar.Sample/Views/MainPage.xaml.cs
+++ b/src/Xalendar.Sample/Xalendar.Sample/Views/MainPage.xaml.cs
@@ -36,7 +36,8 @@ namespace Xalendar.Sample.Views
 
         private void OnDaySelected(DaySelected args)
         {
-            System.Diagnostics.Debug.WriteLine($"Dia selecionado: {args.DateTime}; Eventos: {args.Events.Count()}");
+            if (BindingContext is MainPageViewModel viewModel)
+                viewModel.AddEventsOfDay(args.Events);
         }
     }
 }

--- a/src/Xalendar.Sample/Xalendar.Sample/Views/MainPage.xaml.cs
+++ b/src/Xalendar.Sample/Xalendar.Sample/Views/MainPage.xaml.cs
@@ -34,9 +34,9 @@ namespace Xalendar.Sample.Views
                 viewModel.GetEventsByRange(args.Start, args.End);
         }
 
-        private void OnDaySelected(object obj)
+        private void OnDaySelected(DaySelected args)
         {
-            
+            System.Diagnostics.Debug.WriteLine($"Dia selecionado: {args.DateTime}; Eventos: {args.Events.Count()}");
         }
     }
 }

--- a/src/Xalendar.View/Controls/CalendarView.xaml.cs
+++ b/src/Xalendar.View/Controls/CalendarView.xaml.cs
@@ -115,6 +115,7 @@ namespace Xalendar.View.Controls
         }
 
         public event Action<MonthRange>? MonthChanged;
+        public event Action<object>? DaySelected;
 
         private MonthContainer _monthContainer;
         private int _numberOfDaysInContainer;
@@ -160,6 +161,7 @@ namespace Xalendar.View.Controls
             _selectedDay?.UnSelect();
             calendarDay.Select();
             _selectedDay = calendarDay;
+            DaySelected?.Invoke(null);
         }
 
         public CalendarView()

--- a/src/Xalendar.View/Controls/CalendarView.xaml.cs
+++ b/src/Xalendar.View/Controls/CalendarView.xaml.cs
@@ -115,7 +115,7 @@ namespace Xalendar.View.Controls
         }
 
         public event Action<MonthRange>? MonthChanged;
-        public event Action<object>? DaySelected;
+        public event Action<DaySelected>? DaySelected;
 
         private MonthContainer _monthContainer;
         private int _numberOfDaysInContainer;
@@ -161,7 +161,7 @@ namespace Xalendar.View.Controls
             _selectedDay?.UnSelect();
             calendarDay.Select();
             _selectedDay = calendarDay;
-            DaySelected?.Invoke(null);
+            DaySelected?.Invoke(new DaySelected(calendarDay.Day.DateTime, calendarDay.Day.Events));
         }
 
         public CalendarView()
@@ -244,6 +244,18 @@ namespace Xalendar.View.Controls
         {
             Start = start;
             End = end;
+        }
+    }
+
+    public readonly struct DaySelected
+    {
+        public DateTime DateTime { get; }
+        public IEnumerable<ICalendarViewEvent> Events { get; }
+
+        public DaySelected(DateTime dateTime, IEnumerable<ICalendarViewEvent> events)
+        {
+            DateTime = dateTime;
+            Events = events;
         }
     }
 }

--- a/src/Xalendar.View/Controls/CalendarView.xaml.cs
+++ b/src/Xalendar.View/Controls/CalendarView.xaml.cs
@@ -148,7 +148,7 @@ namespace Xalendar.View.Controls
             }
         }
 
-        private CalendarDay _selectedDay;
+        private CalendarDay? _selectedDay;
 
         private void CalendarDayOnDaySelected(CalendarDay calendarDay)
         {
@@ -172,6 +172,7 @@ namespace Xalendar.View.Controls
         private async void OnPreviousMonthClick(object sender, EventArgs e)
         {
             _selectedDay?.UnSelect();
+            _selectedDay = null;
             
             var result = await Task.Run(() =>
             {
@@ -193,6 +194,7 @@ namespace Xalendar.View.Controls
         private async void OnNextMonthClick(object sender, EventArgs e)
         {
             _selectedDay?.UnSelect();
+            _selectedDay = null;
             
             var result = await Task.Run(() =>
             {


### PR DESCRIPTION
Com essa _pull request_, conseguimos assinar um evento no **CalendarView** para saber quando um dia foi selecionado e também saber quais os eventos que possuem neste dia. Neste momento, não será de responsabilidade do **Xalendar** exibir os eventos do dia selecionado. Isso poderá ser implementado futuramente quando o desenvolvimento do calendário estiver mais avançado.

A título de exemplo, adicionei no projeto _sample_ a exibição dos eventos que existem no dia selecionado.

<img height="600" alt="Imagem do iOS simulator mostrando o calendário com um dia selecionado e uma lista abaixo mostrando os eventos do dia." src="https://user-images.githubusercontent.com/519642/100399172-8140c080-3030-11eb-9e5f-537bf445f1f1.png" />
