### PR TITLE
[Sugestão] Utilização de Lazy<T> para atribuição da responsabilidade de inicialização tardia

### DIFF
--- a/src/Xalendar.View/Controls/CalendarView.xaml.cs
+++ b/src/Xalendar.View/Controls/CalendarView.xaml.cs
@@ -316,7 +316,6 @@ namespace Xalendar.View.Controls
         }
     }
 
-
     public readonly struct MonthRange
     {
         public DateTime Start { get; }


### PR DESCRIPTION
## Descrição

**Ta funcionando no Windows** 😝

Utilizando um encapsulamento para centralizar logicas e melhorar sintaxe de código com o uso de Lazy<T>

> Fiz essa struct a mais com intuito de deixar alguns acessos menos verbosos mas é apenas uma sugestao, poderia usar o Laz<T> diretamente



## Alterações

- Criado `LazyMonthContainer` para encapsular a criação tardia do `MonthContainer`
- Ajustada referencia ao `LazyMonthContainer` para tornar readonly, com a segurança de referencias "não nulas"
- Criados Getter/Setter para acesso à instancia do `MonthContainer` com uma sintaxe menos verbosa que do `Lazy<T>`
- Criada sintaxe fluente como demonstração de possíveis beneficios do encapsulamento da instancia do MonthContainer


