### PR TITLE
Add support to show preview days of previous and next month

### DIFF
--- a/src/Xalendar.Api.Tests/Models/DayTests.cs
+++ b/src/Xalendar.Api.Tests/Models/DayTests.cs
@@ -210,5 +210,29 @@ namespace Xalendar.Api.Tests.Models
             
             Assert.IsEmpty(day.Events);
         }
+
+        [Test]
+        public void DayShouldNotBePreview()
+        {
+            var dateTime = new DateTime(2021, 3, 1);
+            var currentDateTime = new DateTime(2021, 3, 1);
+            var day = new Day(dateTime, currentDateTime);
+
+            var isPreview = day.IsPreview;
+
+            Assert.IsFalse(isPreview);
+        }
+
+        [Test]
+        public void DayShouldBePreview()
+        {
+            var dateTime = new DateTime(2021, 2, 28);
+            var currentDateTime = new DateTime(2021, 3, 1);
+            var day = new Day(dateTime, currentDateTime);
+
+            var isPreview = day.IsPreview;
+
+            Assert.IsTrue(isPreview);
+        }
     }
 }

--- a/src/Xalendar.Api.Tests/Models/DayTests.cs
+++ b/src/Xalendar.Api.Tests/Models/DayTests.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using NUnit.Framework;
-using Xalendar.Api.Extensions;
+using Xalendar.Extensions;
 using Xalendar.Api.Models;
 
 namespace Xalendar.Api.Tests.Models

--- a/src/Xalendar.Api.Tests/Models/DayTests.cs
+++ b/src/Xalendar.Api.Tests/Models/DayTests.cs
@@ -215,8 +215,7 @@ namespace Xalendar.Api.Tests.Models
         public void DayShouldNotBePreview()
         {
             var dateTime = new DateTime(2021, 3, 1);
-            var currentDateTime = new DateTime(2021, 3, 1);
-            var day = new Day(dateTime, currentDateTime);
+            var day = new Day(dateTime);
 
             var isPreview = day.IsPreview;
 
@@ -227,8 +226,7 @@ namespace Xalendar.Api.Tests.Models
         public void DayShouldBePreview()
         {
             var dateTime = new DateTime(2021, 2, 28);
-            var currentDateTime = new DateTime(2021, 3, 1);
-            var day = new Day(dateTime, currentDateTime);
+            var day = new Day(dateTime, isCurrentMonth: false);
 
             var isPreview = day.IsPreview;
 

--- a/src/Xalendar.Api.Tests/Models/MonthContainerTests.cs
+++ b/src/Xalendar.Api.Tests/Models/MonthContainerTests.cs
@@ -86,6 +86,7 @@ namespace Xalendar.Api.Tests.Models
 
             var dateTimeName = monthContainer._month.MonthDateTime.ToString("MMMM yyyy");
             Assert.AreEqual(dateTimeName, monthContainer.GetName());
+            // TODO POSSIVELMENTE EXISTIRÁ MUDANÇA
             Assert.AreEqual(31, monthContainer.Days.Count(day => day is {}));
         }
 
@@ -190,7 +191,19 @@ namespace Xalendar.Api.Tests.Models
 
             var firstDay = monthContainer.FirstDay;
 
+            // TODO POSSIVELMENTE VAI MUDAR
             Assert.AreEqual(new DateTime(2020, 10, 1, 0, 0, 0), firstDay);
+        }
+
+        [Test]
+        public void ShouldGetFirstDayOfMonthContainerWhenPreviewDaysIsActive()
+        {
+            var dateTime = new DateTime(2020, 10, 1);
+            var monthContainer = new MonthContainer(dateTime);
+
+            var firstDay = monthContainer.FirstDay;
+
+            Assert.AreEqual(new DateTime(2020, 9, 27, 0, 0, 0), firstDay);
         }
 
         [Test]
@@ -200,8 +213,20 @@ namespace Xalendar.Api.Tests.Models
             var monthContainer = new MonthContainer(dateTime);
 
             var lastDay = monthContainer.LastDay;
-            
+
+            // TODO POSSIVELMENTE VAI MUDAR
             Assert.AreEqual(new DateTime(2020, 10, 31, 23, 59, 59), lastDay);
+        }
+
+        [Test]
+        public void ShouldGetLastDayOfMonthContainerWhenPreviewDaysIsActive()
+        {
+            var dateTime = new DateTime(2020, 10, 1);
+            var monthContainer = new MonthContainer(dateTime);
+
+            var lastDay = monthContainer.LastDay;
+
+            Assert.AreEqual(new DateTime(2020, 11, 7, 23, 59, 59), lastDay);
         }
 
         [Test]

--- a/src/Xalendar.Api.Tests/Models/MonthContainerTests.cs
+++ b/src/Xalendar.Api.Tests/Models/MonthContainerTests.cs
@@ -231,48 +231,25 @@ namespace Xalendar.Api.Tests.Models
 
         [Test]
         [TestCaseSource(nameof(ValuesForDaysOfMonthShouldStartBasedOnFirstDayOfWeek))]
-        public void DaysOfMonthShouldStartBasedOnFirstDayOfWeek(DateTime dateTime, DayOfWeek firstDayOfWeek, List<Day?> expectedDays)
+        public void DaysOfMonthShouldStartBasedOnFirstDayOfWeek(DateTime dateTime, DayOfWeek firstDayOfWeek, int index)
         {
             var monthContainer = new MonthContainer(dateTime, firstDayOfWeek);
 
             var days = monthContainer.Days;
-            
-            CollectionAssert.AreEqual(expectedDays, days);
+
+            var firstDayOfCurrentMonth = days.First(day => day is { } && day.DateTime.Day == 1);
+            Assert.AreEqual(firstDayOfCurrentMonth, days.ElementAt(index));
         }
 
         private static object[] ValuesForDaysOfMonthShouldStartBasedOnFirstDayOfWeek =
         {
-            new object[] { new DateTime(2020, 9, 1), DayOfWeek.Sunday, GenerateDaysOfSeptember2020(2, 3) },
-            new object[] { new DateTime(2020, 9, 1), DayOfWeek.Monday, GenerateDaysOfSeptember2020(1, 4) },
-            new object[] { new DateTime(2020, 9, 1), DayOfWeek.Tuesday, GenerateDaysOfSeptember2020(0, 5) },
-            new object[] { new DateTime(2020, 9, 1), DayOfWeek.Wednesday, GenerateDaysOfSeptember2020(6, 6) },
-            new object[] { new DateTime(2020, 9, 1), DayOfWeek.Thursday, GenerateDaysOfSeptember2020(5, 7) },
-            new object[] { new DateTime(2020, 9, 1), DayOfWeek.Friday, GenerateDaysOfSeptember2020(4, 1) },
-            new object[] { new DateTime(2020, 9, 1), DayOfWeek.Saturday, GenerateDaysOfSeptember2020(3, 2) }
+            new object[] { new DateTime(2020, 9, 1), DayOfWeek.Sunday, 2},
+            new object[] { new DateTime(2020, 9, 1), DayOfWeek.Monday, 1},
+            new object[] { new DateTime(2020, 9, 1), DayOfWeek.Tuesday, 0},
+            new object[] { new DateTime(2020, 9, 1), DayOfWeek.Wednesday, 6},
+            new object[] { new DateTime(2020, 9, 1), DayOfWeek.Thursday, 5},
+            new object[] { new DateTime(2020, 9, 1), DayOfWeek.Friday, 4},
+            new object[] { new DateTime(2020, 9, 1), DayOfWeek.Saturday, 3}
         };
-
-        private static List<Day?> GenerateDaysOfSeptember2020(int daysToDiscardAtStart, int daysToDiscardAtEnd)
-        {
-            var days = new List<Day?>();
-            
-            for (var index = 0; index < daysToDiscardAtStart; index++)
-                days.Add(default(Day));
-
-            var dateTime = new DateTime(2020, 9, 1);
-            for (var index = 1; index <= 30; index++)
-            {
-                days.Add(new Day(dateTime));
-                dateTime = dateTime.AddDays(1);
-            }
-            
-            for (var index = 0; index < daysToDiscardAtEnd; index++)
-                days.Add(default(Day));
-            
-            if (days.Count < 42)
-                for (var index = days.Count; index < 42; index++)
-                    days.Add(default(Day));
-            
-            return days;
-        }
     }
 }

--- a/src/Xalendar.Api.Tests/Models/MonthContainerTests.cs
+++ b/src/Xalendar.Api.Tests/Models/MonthContainerTests.cs
@@ -47,7 +47,7 @@ namespace Xalendar.Api.Tests.Models
             var dateTime = new DateTime(2020, 7, 9);
             var monthContainer = new MonthContainer(dateTime);
 
-            Assert.IsFalse(monthContainer._month.Days.Any(day => day.HasEvents));
+            Assert.IsFalse(monthContainer._currentMonth.Days.Any(day => day.HasEvents));
         }
 
         [Test]
@@ -62,7 +62,7 @@ namespace Xalendar.Api.Tests.Models
 
             monthContainer.AddEvents(events);
 
-            Assert.IsTrue(monthContainer._month.Days.Any(day => day.HasEvents));
+            Assert.IsTrue(monthContainer._currentMonth.Days.Any(day => day.HasEvents));
         }
 
         [Test]
@@ -84,7 +84,7 @@ namespace Xalendar.Api.Tests.Models
 
             monthContainer.Next();
 
-            var dateTimeName = monthContainer._month.MonthDateTime.ToString("MMMM yyyy");
+            var dateTimeName = monthContainer._currentMonth.MonthDateTime.ToString("MMMM yyyy");
             Assert.AreEqual(dateTimeName, monthContainer.GetName());
             // TODO POSSIVELMENTE EXISTIRÁ MUDANÇA
             Assert.AreEqual(31, monthContainer.Days.Count(day => day is {}));
@@ -98,7 +98,7 @@ namespace Xalendar.Api.Tests.Models
 
             monthContainer.Previous();
 
-            var dateTimeName = monthContainer._month.MonthDateTime.ToString("MMMM yyyy");
+            var dateTimeName = monthContainer._currentMonth.MonthDateTime.ToString("MMMM yyyy");
             Assert.AreEqual(dateTimeName, monthContainer.GetName());
         }
 
@@ -155,7 +155,7 @@ namespace Xalendar.Api.Tests.Models
             
             monthContainer.RemoveEvent(calendarViewEvent);
 
-            Assert.IsFalse(monthContainer._month.Days.Any(day => day.HasEvents));
+            Assert.IsFalse(monthContainer._currentMonth.Days.Any(day => day.HasEvents));
         }
 
         [Test]
@@ -169,7 +169,7 @@ namespace Xalendar.Api.Tests.Models
             
             monthContainer.RemoveAllEvents();
 
-            Assert.IsFalse(monthContainer._month.Days.Any(day => day.HasEvents));
+            Assert.IsFalse(monthContainer._currentMonth.Days.Any(day => day.HasEvents));
         }
 
         [Test]

--- a/src/Xalendar.Api.Tests/Models/MonthContainerTests.cs
+++ b/src/Xalendar.Api.Tests/Models/MonthContainerTests.cs
@@ -199,7 +199,7 @@ namespace Xalendar.Api.Tests.Models
         public void ShouldGetFirstDayOfMonthContainerWhenPreviewDaysIsActive()
         {
             var dateTime = new DateTime(2020, 10, 1);
-            var monthContainer = new MonthContainer(dateTime);
+            var monthContainer = new MonthContainer(dateTime, isPreviewDaysActive: true);
 
             var firstDay = monthContainer.FirstDay;
 
@@ -222,7 +222,7 @@ namespace Xalendar.Api.Tests.Models
         public void ShouldGetLastDayOfMonthContainerWhenPreviewDaysIsActive()
         {
             var dateTime = new DateTime(2020, 10, 1);
-            var monthContainer = new MonthContainer(dateTime);
+            var monthContainer = new MonthContainer(dateTime, isPreviewDaysActive: true);
 
             var lastDay = monthContainer.LastDay;
 

--- a/src/Xalendar.Api.Tests/Models/MonthContainerTests.cs
+++ b/src/Xalendar.Api.Tests/Models/MonthContainerTests.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using NUnit.Framework;
-using Xalendar.Api.Extensions;
+using Xalendar.Extensions;
 using Xalendar.Api.Interfaces;
 using Xalendar.Api.Models;
 

--- a/src/Xalendar.Api.Tests/Models/MonthTests.cs
+++ b/src/Xalendar.Api.Tests/Models/MonthTests.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
-using Xalendar.Api.Extensions;
+using Xalendar.Extensions;
 using Xalendar.Api.Interfaces;
 using Xalendar.Api.Models;
 

--- a/src/Xalendar.Sample/Xalendar.Sample/Views/MainPage.xaml
+++ b/src/Xalendar.Sample/Xalendar.Sample/Views/MainPage.xaml
@@ -23,7 +23,8 @@
             <xal:CalendarView
                 DaySelected="OnDaySelected"
                 Events="{Binding Events}"
-                FirstDayOfWeek="Monday"
+                FirstDayOfWeek="Sunday"
+                IsPreviewDaysActive="True"
                 MonthChanged="OnMonthChanged" />
 
             <ListView

--- a/src/Xalendar.View.Tests/Extensions/IEnumerableExtensionTests.cs
+++ b/src/Xalendar.View.Tests/Extensions/IEnumerableExtensionTests.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
-using Xalendar.View.Extensions;
+using Xalendar.Extensions;
 
 namespace Xalendar.View.Tests.Extensions
 {

--- a/src/Xalendar/Api/Models/Day.cs
+++ b/src/Xalendar/Api/Models/Day.cs
@@ -41,7 +41,9 @@ namespace Xalendar.Api.Models
             get => _isSelected;
             set => _isSelected = value;
         }
-        
+
+        public bool IsPreview => _currentDateTime.Date.Month != DateTime.Date.Month;
+
         public override bool Equals(object obj)
         {
             if (obj is Day dayToCompare)

--- a/src/Xalendar/Api/Models/Day.cs
+++ b/src/Xalendar/Api/Models/Day.cs
@@ -8,6 +8,7 @@ namespace Xalendar.Api.Models
     public class Day
     {
         private DateTime _currentDateTime;
+        private bool _isCurrentMonth;
         public DateTime DateTime { get; }
         public IList<ICalendarViewEvent> Events { get; }
 
@@ -20,13 +21,14 @@ namespace Xalendar.Api.Models
         
         public bool HasEvents => Events.Any();
 
-        public Day(DateTime dateTime, bool isSelected = false) : this(dateTime, DateTime.Now, isSelected)
+        public Day(DateTime dateTime, bool isSelected = false, bool isCurrentMonth = true) : this(dateTime, DateTime.Now, isSelected, isCurrentMonth)
         {
         }
 
-        public Day(DateTime dateTime, DateTime currentDateTime, bool isSelected = false)
+        public Day(DateTime dateTime, DateTime currentDateTime, bool isSelected = false, bool isCurrentMonth = true)
         {
             _currentDateTime = currentDateTime;
+            _isCurrentMonth = isCurrentMonth;
             DateTime = dateTime;
             _isSelected = isSelected;
             Events = new List<ICalendarViewEvent>();
@@ -42,7 +44,7 @@ namespace Xalendar.Api.Models
             set => _isSelected = value;
         }
 
-        public bool IsPreview => _currentDateTime.Date.Month != DateTime.Date.Month;
+        public bool IsPreview => !_isCurrentMonth;
 
         public override bool Equals(object obj)
         {

--- a/src/Xalendar/Api/Models/Month.cs
+++ b/src/Xalendar/Api/Models/Month.cs
@@ -10,10 +10,10 @@ namespace Xalendar.Api.Models
         public DateTime MonthDateTime { get; }
         public IReadOnlyList<Day> Days { get; }
 
-        public Month(DateTime dateTime)
+        public Month(DateTime dateTime, bool isCurrentMonth = true)
         {
             MonthDateTime = dateTime;
-            Days = GenerateDaysOfMonth(dateTime);
+            Days = GenerateDaysOfMonth(dateTime, isCurrentMonth);
         }
 
         public bool Equals(Month other)

--- a/src/Xalendar/Api/Models/Month.cs
+++ b/src/Xalendar/Api/Models/Month.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using static Xalendar.Api.Extensions.MonthExtension;
+using static Xalendar.Extensions.MonthExtension;
 
 namespace Xalendar.Api.Models
 {

--- a/src/Xalendar/Api/Models/MonthContainer.cs
+++ b/src/Xalendar/Api/Models/MonthContainer.cs
@@ -9,7 +9,9 @@ namespace Xalendar.Api.Models
 {
     public class MonthContainer
     {
+        internal Month _previousMonth;
         internal Month _currentMonth;
+        internal Month _nextMonth;
 
         private IReadOnlyList<Day?>? _days;
         public IReadOnlyList<Day?> Days => _days ??= GetDaysOfContainer();
@@ -23,7 +25,9 @@ namespace Xalendar.Api.Models
         
         public MonthContainer(DateTime dateTime, DayOfWeek firstDayOfWeek = DayOfWeek.Sunday)
         {
+            _previousMonth = new Month(dateTime.AddMonths(-1));
             _currentMonth = new Month(dateTime);
+            _nextMonth = new Month(dateTime.AddMonths(1));
             _firstDayOfWeek = firstDayOfWeek;
 
             DaysOfWeek = GenerateDaysOfWeek(firstDayOfWeek)
@@ -53,12 +57,44 @@ namespace Xalendar.Api.Models
         private IReadOnlyList<Day?> GetDaysOfContainer()
         {
             var daysOfContainer = new List<Day?>();
-            this.GetDaysToDiscardAtStartOfMonth(daysOfContainer);
+            //this.GetDaysToDiscardAtStartOfMonth(daysOfContainer);
+            FillDaysOfPreviousMonth(daysOfContainer);
             daysOfContainer.AddRange(_currentMonth.Days);
-            this.GetDaysToDiscardAtEndOfMonth(daysOfContainer);
+            //this.GetDaysToDiscardAtEndOfMonth(daysOfContainer);
+            FillDaysOfNextMonth(daysOfContainer);
             return daysOfContainer;
         }
-        
+
+        private void FillDaysOfPreviousMonth(List<Day?> daysOfContainer)
+        {
+            var firstDay = _currentMonth.Days.First();
+            var differenceOfDays = ((int)_firstDayOfWeek - (int)firstDay!.DateTime.DayOfWeek);
+            var numberOfDaysToShow = differenceOfDays <= 0 ? Math.Abs(differenceOfDays) : 7 - differenceOfDays;
+
+            var days = _previousMonth
+                .Days
+                .Skip(_previousMonth.Days.Count - numberOfDaysToShow)
+                .Take(numberOfDaysToShow);
+
+            foreach (var day in days)
+                daysOfContainer.Add(day);
+        }
+
+        private void FillDaysOfNextMonth(List<Day?> daysOfContainer)
+        {
+            if (daysOfContainer.Count < 42)
+            {
+                var numberOfDaysToShow = 42 - daysOfContainer.Count;
+
+                var days = _nextMonth
+                    .Days
+                    .Take(numberOfDaysToShow);
+
+                foreach (var day in days)
+                    daysOfContainer.Add(day);
+            }
+        }
+
         private void GetDaysToDiscardAtStartOfMonth(List<Day?> daysOfContainer)
         {
             var firstDay = _currentMonth.Days.First();
@@ -79,14 +115,18 @@ namespace Xalendar.Api.Models
         public void Next()
         {
             var nextDateTime = _currentMonth.MonthDateTime.AddMonths(1);
+            _previousMonth = new Month(nextDateTime.AddMonths(-1));
             _currentMonth = new Month(nextDateTime);
+            _nextMonth = new Month(nextDateTime.AddMonths(1));
             _days = null;
         }
 
         public void Previous()
         {
             var previousDateTime = _currentMonth.MonthDateTime.AddMonths(-1);
+            _previousMonth = new Month(previousDateTime.AddMonths(-1));
             _currentMonth = new Month(previousDateTime);
+            _nextMonth = new Month(previousDateTime.AddMonths(1));
             _days = null;
         }
     }

--- a/src/Xalendar/Api/Models/MonthContainer.cs
+++ b/src/Xalendar/Api/Models/MonthContainer.cs
@@ -30,8 +30,8 @@ namespace Xalendar.Api.Models
 
             if (isPreviewDaysActive)
             {
-                _previousMonth = new Month(dateTime.AddMonths(-1), false);
-                _nextMonth = new Month(dateTime.AddMonths(1), false);
+                _previousMonth = new Month(dateTime.AddMonths(-1), isCurrentMonth: false);
+                _nextMonth = new Month(dateTime.AddMonths(1), isCurrentMonth: false);
             }
 
             _firstDayOfWeek = firstDayOfWeek;
@@ -157,8 +157,8 @@ namespace Xalendar.Api.Models
 
             if (_isPreviewDaysActive)
             {
-                _previousMonth = new Month(nextDateTime.AddMonths(-1), false);
-                _nextMonth = new Month(nextDateTime.AddMonths(1), false);
+                _previousMonth = new Month(nextDateTime.AddMonths(-1), isCurrentMonth: false);
+                _nextMonth = new Month(nextDateTime.AddMonths(1), isCurrentMonth: false);
             }
         }
 
@@ -170,8 +170,8 @@ namespace Xalendar.Api.Models
 
             if (_isPreviewDaysActive)
             {
-                _previousMonth = new Month(previousDateTime.AddMonths(-1), false);
-                _nextMonth = new Month(previousDateTime.AddMonths(1), false);
+                _previousMonth = new Month(previousDateTime.AddMonths(-1), isCurrentMonth: false);
+                _nextMonth = new Month(previousDateTime.AddMonths(1), isCurrentMonth: false);
             }
         }
     }

--- a/src/Xalendar/Api/Models/MonthContainer.cs
+++ b/src/Xalendar/Api/Models/MonthContainer.cs
@@ -30,8 +30,8 @@ namespace Xalendar.Api.Models
 
             if (isPreviewDaysActive)
             {
-                _previousMonth = new Month(dateTime.AddMonths(-1));
-                _nextMonth = new Month(dateTime.AddMonths(1));
+                _previousMonth = new Month(dateTime.AddMonths(-1), false);
+                _nextMonth = new Month(dateTime.AddMonths(1), false);
             }
 
             _firstDayOfWeek = firstDayOfWeek;
@@ -157,8 +157,8 @@ namespace Xalendar.Api.Models
 
             if (_isPreviewDaysActive)
             {
-                _previousMonth = new Month(nextDateTime.AddMonths(-1));
-                _nextMonth = new Month(nextDateTime.AddMonths(1));
+                _previousMonth = new Month(nextDateTime.AddMonths(-1), false);
+                _nextMonth = new Month(nextDateTime.AddMonths(1), false);
             }
         }
 
@@ -170,8 +170,8 @@ namespace Xalendar.Api.Models
 
             if (_isPreviewDaysActive)
             {
-                _previousMonth = new Month(previousDateTime.AddMonths(-1));
-                _nextMonth = new Month(previousDateTime.AddMonths(1));
+                _previousMonth = new Month(previousDateTime.AddMonths(-1), false);
+                _nextMonth = new Month(previousDateTime.AddMonths(1), false);
             }
         }
     }

--- a/src/Xalendar/Api/Models/MonthContainer.cs
+++ b/src/Xalendar/Api/Models/MonthContainer.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;
 using System.Linq;
-using Xalendar.Api.Extensions;
+using Xalendar.Extensions;
 
 namespace Xalendar.Api.Models
 {

--- a/src/Xalendar/Api/Models/MonthContainer.cs
+++ b/src/Xalendar/Api/Models/MonthContainer.cs
@@ -9,7 +9,7 @@ namespace Xalendar.Api.Models
 {
     public class MonthContainer
     {
-        internal Month _month;
+        internal Month _currentMonth;
 
         private IReadOnlyList<Day?>? _days;
         public IReadOnlyList<Day?> Days => _days ??= GetDaysOfContainer();
@@ -23,7 +23,7 @@ namespace Xalendar.Api.Models
         
         public MonthContainer(DateTime dateTime, DayOfWeek firstDayOfWeek = DayOfWeek.Sunday)
         {
-            _month = new Month(dateTime);
+            _currentMonth = new Month(dateTime);
             _firstDayOfWeek = firstDayOfWeek;
 
             DaysOfWeek = GenerateDaysOfWeek(firstDayOfWeek)
@@ -54,14 +54,14 @@ namespace Xalendar.Api.Models
         {
             var daysOfContainer = new List<Day?>();
             this.GetDaysToDiscardAtStartOfMonth(daysOfContainer);
-            daysOfContainer.AddRange(_month.Days);
+            daysOfContainer.AddRange(_currentMonth.Days);
             this.GetDaysToDiscardAtEndOfMonth(daysOfContainer);
             return daysOfContainer;
         }
         
         private void GetDaysToDiscardAtStartOfMonth(List<Day?> daysOfContainer)
         {
-            var firstDay = _month.Days.First();
+            var firstDay = _currentMonth.Days.First();
             var differenceOfDays = ((int)_firstDayOfWeek - (int) firstDay!.DateTime.DayOfWeek);
             var numberOfDaysToDiscard = differenceOfDays <= 0 ? Math.Abs(differenceOfDays) : 7 - differenceOfDays;  
             
@@ -78,15 +78,15 @@ namespace Xalendar.Api.Models
         
         public void Next()
         {
-            var nextDateTime = _month.MonthDateTime.AddMonths(1);
-            _month = new Month(nextDateTime);
+            var nextDateTime = _currentMonth.MonthDateTime.AddMonths(1);
+            _currentMonth = new Month(nextDateTime);
             _days = null;
         }
 
         public void Previous()
         {
-            var previousDateTime = _month.MonthDateTime.AddMonths(-1);
-            _month = new Month(previousDateTime);
+            var previousDateTime = _currentMonth.MonthDateTime.AddMonths(-1);
+            _currentMonth = new Month(previousDateTime);
             _days = null;
         }
     }

--- a/src/Xalendar/Api/Models/MonthContainer.cs
+++ b/src/Xalendar/Api/Models/MonthContainer.cs
@@ -9,9 +9,9 @@ namespace Xalendar.Api.Models
 {
     public class MonthContainer
     {
-        internal Month _previousMonth;
+        internal Month? _previousMonth;
         internal Month _currentMonth;
-        internal Month _nextMonth;
+        internal Month? _nextMonth;
 
         private IReadOnlyList<Day?>? _days;
         public IReadOnlyList<Day?> Days => _days ??= GetDaysOfContainer();
@@ -22,13 +22,20 @@ namespace Xalendar.Api.Models
         public DateTime LastDay => Days.Last(day => day is {})!.DateTime.AddHours(23).AddMinutes(59).AddSeconds(59);
 
         private DayOfWeek _firstDayOfWeek;
+        private bool _isPreviewDaysActive;
         
-        public MonthContainer(DateTime dateTime, DayOfWeek firstDayOfWeek = DayOfWeek.Sunday)
+        public MonthContainer(DateTime dateTime, DayOfWeek firstDayOfWeek = DayOfWeek.Sunday, bool isPreviewDaysActive = false)
         {
-            _previousMonth = new Month(dateTime.AddMonths(-1));
             _currentMonth = new Month(dateTime);
-            _nextMonth = new Month(dateTime.AddMonths(1));
+
+            if (isPreviewDaysActive)
+            {
+                _previousMonth = new Month(dateTime.AddMonths(-1));
+                _nextMonth = new Month(dateTime.AddMonths(1));
+            }
+
             _firstDayOfWeek = firstDayOfWeek;
+            _isPreviewDaysActive = isPreviewDaysActive;
 
             DaysOfWeek = GenerateDaysOfWeek(firstDayOfWeek)
                 .Select(GetDayOfWeekAbbreviated)
@@ -57,37 +64,36 @@ namespace Xalendar.Api.Models
         private IReadOnlyList<Day?> GetDaysOfContainer()
         {
             var daysOfContainer = new List<Day?>();
-            //this.GetDaysToDiscardAtStartOfMonth(daysOfContainer);
+
             FillDaysOfPreviousMonth(daysOfContainer);
-            daysOfContainer.AddRange(_currentMonth.Days);
-            //this.GetDaysToDiscardAtEndOfMonth(daysOfContainer);
+            FillDaysOfCurrentMonth(daysOfContainer);
             FillDaysOfNextMonth(daysOfContainer);
+
             return daysOfContainer;
         }
 
         private void FillDaysOfPreviousMonth(List<Day?> daysOfContainer)
         {
-            var firstDay = _currentMonth.Days.First();
-            var differenceOfDays = ((int)_firstDayOfWeek - (int)firstDay!.DateTime.DayOfWeek);
-            var numberOfDaysToShow = differenceOfDays <= 0 ? Math.Abs(differenceOfDays) : 7 - differenceOfDays;
+            if (_isPreviewDaysActive)
+            {
+                FillPreviewDaysOfPreviousMonth(daysOfContainer);
+                return;
+            }
 
-            var days = _previousMonth
-                .Days
-                .Skip(_previousMonth.Days.Count - numberOfDaysToShow)
-                .Take(numberOfDaysToShow);
-
-            foreach (var day in days)
-                daysOfContainer.Add(day);
+            DiscardDaysOfPreviousMonth(daysOfContainer);
         }
 
-        private void FillDaysOfNextMonth(List<Day?> daysOfContainer)
+        private void FillPreviewDaysOfPreviousMonth(List<Day?> daysOfContainer)
         {
-            if (daysOfContainer.Count < 42)
+            if (_previousMonth is Month { } previousMonth)
             {
-                var numberOfDaysToShow = 42 - daysOfContainer.Count;
+                var firstDay = _currentMonth.Days.First();
+                var differenceOfDays = ((int)_firstDayOfWeek - (int)firstDay!.DateTime.DayOfWeek);
+                var numberOfDaysToShow = differenceOfDays <= 0 ? Math.Abs(differenceOfDays) : 7 - differenceOfDays;
 
-                var days = _nextMonth
+                var days = previousMonth
                     .Days
+                    .Skip(previousMonth.Days.Count - numberOfDaysToShow)
                     .Take(numberOfDaysToShow);
 
                 foreach (var day in days)
@@ -95,7 +101,7 @@ namespace Xalendar.Api.Models
             }
         }
 
-        private void GetDaysToDiscardAtStartOfMonth(List<Day?> daysOfContainer)
+        private void DiscardDaysOfPreviousMonth(List<Day?> daysOfContainer)
         {
             var firstDay = _currentMonth.Days.First();
             var differenceOfDays = ((int)_firstDayOfWeek - (int) firstDay!.DateTime.DayOfWeek);
@@ -104,8 +110,39 @@ namespace Xalendar.Api.Models
             for (var index = 0; index < numberOfDaysToDiscard; index++)
                 daysOfContainer.Add(default(Day));
         }
-        
-        private void GetDaysToDiscardAtEndOfMonth(List<Day?> daysOfContainer)
+
+        private void FillDaysOfCurrentMonth(List<Day?> daysOfContainer) => daysOfContainer.AddRange(_currentMonth.Days);
+
+        private void FillDaysOfNextMonth(List<Day?> daysOfContainer)
+        {
+            if (_isPreviewDaysActive)
+            {
+                FillPreviewDaysOfNextMonth(daysOfContainer);
+                return;
+            }
+
+            DiscardDaysOfNextMonth(daysOfContainer);
+        }
+
+        private void FillPreviewDaysOfNextMonth(List<Day?> daysOfContainer)
+        {
+            if (_nextMonth is Month { } nextMonth)
+            {
+                if (daysOfContainer.Count < 42)
+                {
+                    var numberOfDaysToShow = 42 - daysOfContainer.Count;
+
+                    var days = nextMonth
+                        .Days
+                        .Take(numberOfDaysToShow);
+
+                    foreach (var day in days)
+                        daysOfContainer.Add(day);
+                }
+            }
+        }
+
+        private void DiscardDaysOfNextMonth(List<Day?> daysOfContainer)
         {
             if (daysOfContainer.Count < 42)
                 for (var index = daysOfContainer.Count; index < 42; index++)
@@ -115,19 +152,27 @@ namespace Xalendar.Api.Models
         public void Next()
         {
             var nextDateTime = _currentMonth.MonthDateTime.AddMonths(1);
-            _previousMonth = new Month(nextDateTime.AddMonths(-1));
             _currentMonth = new Month(nextDateTime);
-            _nextMonth = new Month(nextDateTime.AddMonths(1));
             _days = null;
+
+            if (_isPreviewDaysActive)
+            {
+                _previousMonth = new Month(nextDateTime.AddMonths(-1));
+                _nextMonth = new Month(nextDateTime.AddMonths(1));
+            }
         }
 
         public void Previous()
         {
             var previousDateTime = _currentMonth.MonthDateTime.AddMonths(-1);
-            _previousMonth = new Month(previousDateTime.AddMonths(-1));
             _currentMonth = new Month(previousDateTime);
-            _nextMonth = new Month(previousDateTime.AddMonths(1));
             _days = null;
+
+            if (_isPreviewDaysActive)
+            {
+                _previousMonth = new Month(previousDateTime.AddMonths(-1));
+                _nextMonth = new Month(previousDateTime.AddMonths(1));
+            }
         }
     }
 }

--- a/src/Xalendar/Extensions/DayExtension.cs
+++ b/src/Xalendar/Extensions/DayExtension.cs
@@ -2,7 +2,7 @@ using System;
 using Xalendar.Api.Interfaces;
 using Xalendar.Api.Models;
 
-namespace Xalendar.Api.Extensions
+namespace Xalendar.Extensions
 {
     public static class DayExtension
     {

--- a/src/Xalendar/Extensions/IEnumerableExtension.cs
+++ b/src/Xalendar/Extensions/IEnumerableExtension.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 
-namespace Xalendar.View.Extensions
+namespace Xalendar.Extensions
 {
     public static class IEnumerableExtension
     {

--- a/src/Xalendar/Extensions/MonthContainerExtension.cs
+++ b/src/Xalendar/Extensions/MonthContainerExtension.cs
@@ -3,7 +3,7 @@ using System.Linq;
 using Xalendar.Api.Interfaces;
 using Xalendar.Api.Models;
 
-namespace Xalendar.Api.Extensions
+namespace Xalendar.Extensions
 {
     public static class MonthContainerExtension
     {

--- a/src/Xalendar/Extensions/MonthContainerExtension.cs
+++ b/src/Xalendar/Extensions/MonthContainerExtension.cs
@@ -7,16 +7,16 @@ namespace Xalendar.Extensions
 {
     public static class MonthContainerExtension
     {
-        public static void SelectDay(this MonthContainer monthContainer, Day selectedDay) => monthContainer._month.SelectDay(selectedDay);
-        public static Day GetSelectedDay(this MonthContainer monthContainer) => monthContainer._month.GetSelectedDay();
-        public static void AddEvents(this MonthContainer monthContainer, IEnumerable<ICalendarViewEvent> events) => monthContainer._month.AddEvents(events);
+        public static void SelectDay(this MonthContainer monthContainer, Day selectedDay) => monthContainer._currentMonth.SelectDay(selectedDay);
+        public static Day GetSelectedDay(this MonthContainer monthContainer) => monthContainer._currentMonth.GetSelectedDay();
+        public static void AddEvents(this MonthContainer monthContainer, IEnumerable<ICalendarViewEvent> events) => monthContainer._currentMonth.AddEvents(events);
 
         public static void RemoveEvent(this MonthContainer monthContainer, ICalendarViewEvent calendarViewEvent) =>
-            monthContainer._month.RemoveEvent(calendarViewEvent);
+            monthContainer._currentMonth.RemoveEvent(calendarViewEvent);
 
         public static void RemoveAllEvents(this MonthContainer monthContainer) =>
-            monthContainer._month.RemoveAllEvents();
+            monthContainer._currentMonth.RemoveAllEvents();
         
-        public static string GetName(this MonthContainer monthContainer) => monthContainer._month.MonthDateTime.ToString("MMMM yyyy");
+        public static string GetName(this MonthContainer monthContainer) => monthContainer._currentMonth.MonthDateTime.ToString("MMMM yyyy");
     }
 }

--- a/src/Xalendar/Extensions/MonthExtension.cs
+++ b/src/Xalendar/Extensions/MonthExtension.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using Xalendar.Api.Interfaces;
 using Xalendar.Api.Models;
 
-namespace Xalendar.Api.Extensions
+namespace Xalendar.Extensions
 {
     public static class MonthExtension
     {

--- a/src/Xalendar/Extensions/MonthExtension.cs
+++ b/src/Xalendar/Extensions/MonthExtension.cs
@@ -38,12 +38,12 @@ namespace Xalendar.Extensions
             return month.Days.FirstOrDefault(day => day.IsSelected);
         }
         
-        public static List<Day> GenerateDaysOfMonth(DateTime dateTime)
+        public static List<Day> GenerateDaysOfMonth(DateTime dateTime, bool isCurrentMonth = true)
         {
             return Enumerable
                 .Range(1, DateTime.DaysInMonth(dateTime.Year, dateTime.Month))
                 .Select(dayValue => new DateTime(dateTime.Year, dateTime.Month, dayValue))
-                .Select(dateTime => new Day(dateTime))
+                .Select(dateTime => new Day(dateTime, isCurrentMonth: isCurrentMonth))
                 .ToList();
         }
 

--- a/src/Xalendar/View/Controls/CalendarDay.xaml.cs
+++ b/src/Xalendar/View/Controls/CalendarDay.xaml.cs
@@ -50,6 +50,9 @@ namespace Xalendar.View.Controls
                 if (Day.IsToday)
                     return "IsToday";
 
+                if (Day.IsWeekend)
+                    return "IsWeekend";
+
                 if (Day.IsPreview)
                     return "IsPreview";
             }

--- a/src/Xalendar/View/Controls/CalendarDay.xaml.cs
+++ b/src/Xalendar/View/Controls/CalendarDay.xaml.cs
@@ -28,8 +28,33 @@ namespace Xalendar.View.Controls
 
         internal void StartState()
         {
-            var state = Day is { } && Day.IsToday ? "IsToday" : "UnSelected";
-            VisualStateManager.GoToState(DayFrame, state);
+            VisualStateManager.GoToState(DayFrame, GetStateOfDayFrame());
+            VisualStateManager.GoToState(DayElement, GetStateOfDayElement());
+        }
+
+        private string GetStateOfDayFrame()
+        {
+            if (Day is { })
+            {
+                if (Day.IsToday)
+                    return "IsToday";
+            }
+
+            return "UnSelected";
+        }
+
+        private string GetStateOfDayElement()
+        {
+            if (Day is { })
+            {
+                if (Day.IsToday)
+                    return "IsToday";
+
+                if (Day.IsPreview)
+                    return "IsPreview";
+            }
+
+            return "IsNotPreview";
         }
     }
 }

--- a/src/Xalendar/View/Controls/CalendarView.xaml.cs
+++ b/src/Xalendar/View/Controls/CalendarView.xaml.cs
@@ -123,6 +123,20 @@ namespace Xalendar.View.Controls
             set => SetValue(FirstDayOfWeekProperty, value);
         }
 
+        public static BindableProperty IsPreviewDaysActiveProperty =
+            BindableProperty.Create(
+                nameof(IsPreviewDaysActive),
+                typeof(bool),
+                typeof(CalendarView),
+                false,
+                BindingMode.OneTime);
+
+        public bool IsPreviewDaysActive
+        {
+            get => (bool)GetValue(IsPreviewDaysActiveProperty);
+            set => SetValue(IsPreviewDaysActiveProperty, value);
+        }
+
         public event Action<MonthRange>? MonthChanged;
         public event Action<DaySelected>? DaySelected;
 
@@ -135,7 +149,7 @@ namespace Xalendar.View.Controls
 
             if (propertyName == "Renderer")
             {
-                _monthContainer = new MonthContainer(DateTime.Today, FirstDayOfWeek);
+                _monthContainer = new MonthContainer(DateTime.Today, FirstDayOfWeek, IsPreviewDaysActive);
                 
                 if (!Events.IsNullOrEmpty())
                     _monthContainer.AddEvents(Events);

--- a/src/Xalendar/View/Controls/CalendarView.xaml.cs
+++ b/src/Xalendar/View/Controls/CalendarView.xaml.cs
@@ -4,10 +4,9 @@ using System.Collections.Specialized;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
-using Xalendar.Api.Extensions;
+using Xalendar.Extensions;
 using Xalendar.Api.Interfaces;
 using Xalendar.Api.Models;
-using Xalendar.View.Extensions;
 using Xamarin.Forms;
 using XView = Xamarin.Forms.View;
 

--- a/src/Xalendar/View/Themes/Classic.xaml
+++ b/src/Xalendar/View/Themes/Classic.xaml
@@ -79,10 +79,39 @@
     </Style>
 
     <Style Class="DayElement" TargetType="Label">
-        <Setter Property="TextColor" Value="Black" />
         <Setter Property="FontSize" Value="Subtitle" />
         <Setter Property="HorizontalTextAlignment" Value="Center" />
         <Setter Property="VerticalTextAlignment" Value="Center" />
+
+        <Setter Property="VisualStateManager.VisualStateGroups">
+            <VisualStateGroupList>
+                <VisualStateGroup>
+                    <VisualState x:Name="IsPreview">
+                        <VisualState.Setters>
+                            <Setter Property="TextColor" Value="Gray" />
+                        </VisualState.Setters>
+                    </VisualState>
+
+                    <VisualState x:Name="IsWeekend">
+                        <VisualState.Setters>
+                            <Setter Property="TextColor" Value="Gray" />
+                        </VisualState.Setters>
+                    </VisualState>
+
+                    <VisualState x:Name="IsToday">
+                        <VisualState.Setters>
+                            <Setter Property="TextColor" Value="Black" />
+                        </VisualState.Setters>
+                    </VisualState>
+
+                    <VisualState x:Name="IsNotPreview">
+                        <VisualState.Setters>
+                            <Setter Property="TextColor" Value="Black" />
+                        </VisualState.Setters>
+                    </VisualState>
+                </VisualStateGroup>
+            </VisualStateGroupList>
+        </Setter>
     </Style>
 
     <Style Class="HasEventsElement" TargetType="BoxView">

--- a/src/Xalendar/View/Themes/Planning.xaml
+++ b/src/Xalendar/View/Themes/Planning.xaml
@@ -90,10 +90,33 @@
 
     <Style Class="DayElement" TargetType="Label">
         <Setter Property="FontSize" Value="Body" />
-        <Setter Property="TextColor" Value="Black" />
         <Setter Property="Margin" Value="4,0,4,0" />
         <Setter Property="HorizontalTextAlignment" Value="Center" />
         <Setter Property="VerticalTextAlignment" Value="Center" />
+
+        <Setter Property="VisualStateManager.VisualStateGroups">
+            <VisualStateGroupList>
+                <VisualStateGroup>
+                    <VisualState x:Name="IsPreview">
+                        <VisualState.Setters>
+                            <Setter Property="TextColor" Value="#D9D6E9" />
+                        </VisualState.Setters>
+                    </VisualState>
+
+                    <VisualState x:Name="IsToday">
+                        <VisualState.Setters>
+                            <Setter Property="TextColor" Value="Black" />
+                        </VisualState.Setters>
+                    </VisualState>
+
+                    <VisualState x:Name="IsNotPreview">
+                        <VisualState.Setters>
+                            <Setter Property="TextColor" Value="Black" />
+                        </VisualState.Setters>
+                    </VisualState>
+                </VisualStateGroup>
+            </VisualStateGroupList>
+        </Setter>
     </Style>
 
     <Style Class="HasEventsElement" TargetType="BoxView">

--- a/src/Xalendar/View/Themes/Planning.xaml
+++ b/src/Xalendar/View/Themes/Planning.xaml
@@ -103,6 +103,12 @@
                         </VisualState.Setters>
                     </VisualState>
 
+                    <VisualState x:Name="IsWeekend">
+                        <VisualState.Setters>
+                            <Setter Property="TextColor" Value="#D9D6E9" />
+                        </VisualState.Setters>
+                    </VisualState>
+
                     <VisualState x:Name="IsToday">
                         <VisualState.Setters>
                             <Setter Property="TextColor" Value="Black" />


### PR DESCRIPTION
Now the Xalendar can show the preview of previous and next days of the month. Exists an attribute in CalendarView to control this. Was created the style for these days too.

Another thing that this pull request has is the style of the weekend days. 