### PR TITLE
Add multi select support

### DIFF
--- a/src/Xalendar.Sample/Xalendar.Sample/ViewModels/MainPageViewModel.cs
+++ b/src/Xalendar.Sample/Xalendar.Sample/ViewModels/MainPageViewModel.cs
@@ -17,6 +17,7 @@ namespace Xalendar.Sample.ViewModels
                 new SamplePage { Name = "Changing month", Type = typeof(ChangingMonth) },
                 new SamplePage { Name = "Selecting day (legacy)", Type = typeof(SelectingDayLegacy) },
                 new SamplePage { Name = "Selecting day - single mode", Type = typeof(SelectingDaySingle) },
+                new SamplePage { Name = "Selecting day - multi mode", Type = typeof(SelectingDayMulti) },
                 new SamplePage { Name = "Choosing theme", Type = typeof(ChoosingTheme) }
             };
         }

--- a/src/Xalendar.Sample/Xalendar.Sample/ViewModels/MainPageViewModel.cs
+++ b/src/Xalendar.Sample/Xalendar.Sample/ViewModels/MainPageViewModel.cs
@@ -15,7 +15,7 @@ namespace Xalendar.Sample.ViewModels
                 new SamplePage { Name = "Basic sample", Type = typeof(Basic) },
                 new SamplePage { Name = "Adding events", Type = typeof(AddingEvents) },
                 new SamplePage { Name = "Changing month", Type = typeof(ChangingMonth) },
-                new SamplePage { Name = "Selecting day", Type = typeof(SelectingDay) },
+                new SamplePage { Name = "Selecting day (legacy)", Type = typeof(SelectingDayLegacy) },
                 new SamplePage { Name = "Choosing theme", Type = typeof(ChoosingTheme) }
             };
         }

--- a/src/Xalendar.Sample/Xalendar.Sample/ViewModels/MainPageViewModel.cs
+++ b/src/Xalendar.Sample/Xalendar.Sample/ViewModels/MainPageViewModel.cs
@@ -16,6 +16,7 @@ namespace Xalendar.Sample.ViewModels
                 new SamplePage { Name = "Adding events", Type = typeof(AddingEvents) },
                 new SamplePage { Name = "Changing month", Type = typeof(ChangingMonth) },
                 new SamplePage { Name = "Selecting day (legacy)", Type = typeof(SelectingDayLegacy) },
+                new SamplePage { Name = "Selecting day - single mode", Type = typeof(SelectingDaySingle) },
                 new SamplePage { Name = "Choosing theme", Type = typeof(ChoosingTheme) }
             };
         }

--- a/src/Xalendar.Sample/Xalendar.Sample/Views/SelectingDayLegacy.xaml
+++ b/src/Xalendar.Sample/Xalendar.Sample/Views/SelectingDayLegacy.xaml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="UTF-8" ?>
 <ContentPage
-    x:Class="Xalendar.Sample.Views.SelectingDay"
+    x:Class="Xalendar.Sample.Views.SelectingDayLegacy"
     xmlns="http://xamarin.com/schemas/2014/forms"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:xal="http://xalendar.com/schemas/xaml">

--- a/src/Xalendar.Sample/Xalendar.Sample/Views/SelectingDayLegacyLegacy.cs
+++ b/src/Xalendar.Sample/Xalendar.Sample/Views/SelectingDayLegacyLegacy.cs
@@ -6,9 +6,9 @@ using Xamarin.Forms;
 
 namespace Xalendar.Sample.Views
 {
-    public partial class SelectingDay : ContentPage
+    public partial class SelectingDayLegacy : ContentPage
     {
-        public SelectingDay()
+        public SelectingDayLegacy()
         {
             InitializeComponent();
         }

--- a/src/Xalendar.Sample/Xalendar.Sample/Views/SelectingDayMulti.xaml
+++ b/src/Xalendar.Sample/Xalendar.Sample/Views/SelectingDayMulti.xaml
@@ -5,19 +5,27 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:xal="http://xalendar.com/schemas/xaml">
     <ContentPage.Content>
-        <StackLayout>
-            <xal:CalendarView DayTapped="OnDayTapped" SelectMode="Multi" />
+        <ScrollView>
+            <StackLayout>
+                <xal:CalendarView
+                    x:Name="Calendar"
+                    DayTapped="OnDayTapped"
+                    SelectMode="Multi" />
 
-            <StackLayout Margin="15,0">
-                <Label Text="Tapped day:" />
-                <Label x:Name="TappedDay" />
+                <StackLayout Margin="15,0">
+                    <Label Text="Tapped day:" />
+                    <Label x:Name="TappedDay" />
 
-                <Label Margin="0,20,0,0" Text="State:" />
-                <Label x:Name="State" />
+                    <Label Margin="0,20,0,0" Text="State of tapped day:" />
+                    <Label x:Name="State" />
 
-                <Label Margin="0,20,0,0" Text="Amount of events:" />
-                <Label x:Name="AmountEvents" />
+                    <Label Margin="0,20,0,0" Text="Amount of events of tapped day:" />
+                    <Label x:Name="AmountEvents" />
+
+                    <Label Margin="0,20,0,0" Text="Selected days:" />
+                    <StackLayout x:Name="SelectedDays" />
+                </StackLayout>
             </StackLayout>
-        </StackLayout>
+        </ScrollView>
     </ContentPage.Content>
 </ContentPage>

--- a/src/Xalendar.Sample/Xalendar.Sample/Views/SelectingDayMulti.xaml
+++ b/src/Xalendar.Sample/Xalendar.Sample/Views/SelectingDayMulti.xaml
@@ -1,0 +1,23 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<ContentPage
+    x:Class="Xalendar.Sample.Views.SelectingDayMulti"
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:xal="http://xalendar.com/schemas/xaml">
+    <ContentPage.Content>
+        <StackLayout>
+            <xal:CalendarView DayTapped="OnDayTapped" SelectMode="Multi" />
+
+            <StackLayout Margin="15,0">
+                <Label Text="Tapped day:" />
+                <Label x:Name="TappedDay" />
+
+                <Label Margin="0,20,0,0" Text="State:" />
+                <Label x:Name="State" />
+
+                <Label Margin="0,20,0,0" Text="Amount of events:" />
+                <Label x:Name="AmountEvents" />
+            </StackLayout>
+        </StackLayout>
+    </ContentPage.Content>
+</ContentPage>

--- a/src/Xalendar.Sample/Xalendar.Sample/Views/SelectingDayMulti.xaml.cs
+++ b/src/Xalendar.Sample/Xalendar.Sample/Views/SelectingDayMulti.xaml.cs
@@ -17,6 +17,10 @@ namespace Xalendar.Sample.Views
             TappedDay.Text = dayTapped.DateTime.ToString("G");
             State.Text = dayTapped.State.ToString();
             AmountEvents.Text = dayTapped.Events.Count().ToString();
+            
+            SelectedDays.Children.Clear();
+            foreach (var dateTime in Calendar.SelectedDates)
+                SelectedDays.Children.Add(new Label { Text = dateTime.ToString("G") });
         }
     }
 }

--- a/src/Xalendar.Sample/Xalendar.Sample/Views/SelectingDayMulti.xaml.cs
+++ b/src/Xalendar.Sample/Xalendar.Sample/Views/SelectingDayMulti.xaml.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xamarin.Forms;
+
+namespace Xalendar.Sample.Views
+{
+    public partial class SelectingDayMulti : ContentPage
+    {
+        public SelectingDayMulti()
+        {
+            InitializeComponent();
+        }
+
+        private void OnDayTapped(Xalendar.Api.Models.DayTapped dayTapped)
+        {
+            TappedDay.Text = dayTapped.DateTime.ToString("G");
+            State.Text = dayTapped.State.ToString();
+            AmountEvents.Text = dayTapped.Events.Count().ToString();
+        }
+    }
+}

--- a/src/Xalendar.Sample/Xalendar.Sample/Views/SelectingDaySingle.xaml
+++ b/src/Xalendar.Sample/Xalendar.Sample/Views/SelectingDaySingle.xaml
@@ -5,19 +5,21 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:xal="http://xalendar.com/schemas/xaml">
     <ContentPage.Content>
-        <StackLayout>
-            <xal:CalendarView DayTapped="OnDayTapped" />
+        <ScrollView>
+            <StackLayout>
+                <xal:CalendarView DayTapped="OnDayTapped" />
 
-            <StackLayout Margin="15,0">
-                <Label Text="Tapped day:" />
-                <Label x:Name="TappedDay" />
+                <StackLayout Margin="15,0">
+                    <Label Text="Tapped day:" />
+                    <Label x:Name="TappedDay" />
 
-                <Label Margin="0,20,0,0" Text="State:" />
-                <Label x:Name="State" />
+                    <Label Margin="0,20,0,0" Text="State:" />
+                    <Label x:Name="State" />
 
-                <Label Margin="0,20,0,0" Text="Amount of events:" />
-                <Label x:Name="AmountEvents" />
+                    <Label Margin="0,20,0,0" Text="Amount of events:" />
+                    <Label x:Name="AmountEvents" />
+                </StackLayout>
             </StackLayout>
-        </StackLayout>
+        </ScrollView>
     </ContentPage.Content>
 </ContentPage>

--- a/src/Xalendar.Sample/Xalendar.Sample/Views/SelectingDaySingle.xaml
+++ b/src/Xalendar.Sample/Xalendar.Sample/Views/SelectingDaySingle.xaml
@@ -1,0 +1,23 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<ContentPage
+    x:Class="Xalendar.Sample.Views.SelectingDaySingle"
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:xal="http://xalendar.com/schemas/xaml">
+    <ContentPage.Content>
+        <StackLayout>
+            <xal:CalendarView DayTapped="OnDayTapped" />
+
+            <StackLayout Margin="15,0">
+                <Label Text="Tapped day:" />
+                <Label x:Name="TappedDay" />
+
+                <Label Margin="0,20,0,0" Text="State:" />
+                <Label x:Name="State" />
+
+                <Label Margin="0,20,0,0" Text="Amount of events:" />
+                <Label x:Name="AmountEvents" />
+            </StackLayout>
+        </StackLayout>
+    </ContentPage.Content>
+</ContentPage>

--- a/src/Xalendar.Sample/Xalendar.Sample/Views/SelectingDaySingle.xaml.cs
+++ b/src/Xalendar.Sample/Xalendar.Sample/Views/SelectingDaySingle.xaml.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xamarin.Forms;
+
+namespace Xalendar.Sample.Views
+{
+    public partial class SelectingDaySingle : ContentPage
+    {
+        public SelectingDaySingle()
+        {
+            InitializeComponent();
+        }
+
+        private void OnDayTapped(Xalendar.Api.Models.DayTapped dayTapped)
+        {
+            TappedDay.Text = dayTapped.DateTime.ToString("G");
+            State.Text = dayTapped.State.ToString();
+            AmountEvents.Text = dayTapped.Events.Count().ToString();
+        }
+    }
+}

--- a/src/Xalendar.Tests/Api/Models/DayTests.cs
+++ b/src/Xalendar.Tests/Api/Models/DayTests.cs
@@ -232,5 +232,25 @@ namespace Xalendar.Tests.Api.Models
 
             Assert.IsTrue(isPreview);
         }
+
+        [Test]
+        public void ShouldChangeSelectedStateToFalse()
+        {
+            var day = new Day(DateTime.Now, true);
+            
+            day.SwitchSelectedState();
+            
+            Assert.IsFalse(day.IsSelected);
+        }
+
+        [Test]
+        public void ShouldChangeSelectedStateToTrue()
+        {
+            var day = new Day(DateTime.Now, false);
+            
+            day.SwitchSelectedState();
+            
+            Assert.IsTrue(day.IsSelected);
+        }
     }
 }

--- a/src/Xalendar.Tests/View/Controls/CalendarViewTests.cs
+++ b/src/Xalendar.Tests/View/Controls/CalendarViewTests.cs
@@ -308,5 +308,30 @@ namespace Xalendar.Tests.View.Controls
             
             Assert.IsEmpty(_calendarView.SelectedDates);
         }
+
+        [Test]
+        public async Task ShouldKeepSelectedStateWhenSelectModeIsMultiAndNavigateBetweenMonths()
+        {
+            _calendarView.SelectMode = SelectMode.Multi;
+            
+            var selectTaskCompletionSource = new TaskCompletionSource<DayTapped>();
+            _calendarView.DayTapped += selectTaskCompletionSource.SetResult;
+            var firstValidCalendarDay = GetFirstValidCalendarDay();
+            SendTapped(firstValidCalendarDay);
+            await selectTaskCompletionSource.Task;
+
+            var previousTaskCompletionSource = new TaskCompletionSource<MonthRange>();
+            _calendarView.MonthChanged += previousTaskCompletionSource.SetResult;
+            InvokeCalendarViewMethod("OnPreviousMonthClick", new object[] {null, EventArgs.Empty});
+            await previousTaskCompletionSource.Task;
+            _calendarView.MonthChanged -= previousTaskCompletionSource.SetResult;
+
+            var nextTaskCompletionSource = new TaskCompletionSource<MonthRange>();
+            _calendarView.MonthChanged += nextTaskCompletionSource.SetResult;
+            InvokeCalendarViewMethod("OnNextMonthClick", new object[] {null, EventArgs.Empty});
+            await nextTaskCompletionSource.Task;
+
+            Assert.IsTrue(firstValidCalendarDay.Day!.IsSelected);
+        }
     }
 }

--- a/src/Xalendar.Tests/View/Controls/CalendarViewTests.cs
+++ b/src/Xalendar.Tests/View/Controls/CalendarViewTests.cs
@@ -333,5 +333,30 @@ namespace Xalendar.Tests.View.Controls
 
             Assert.IsTrue(firstValidCalendarDay.Day!.IsSelected);
         }
+
+        [Test]
+        public async Task ShouldDiscardSelectedStateWhenSelectModeIsSingleAndNavigateBetweenMonths()
+        {
+            _calendarView.SelectMode = SelectMode.Single;
+
+            var selectTaskCompletionSource = new TaskCompletionSource<DayTapped>();
+            _calendarView.DayTapped += selectTaskCompletionSource.SetResult;
+            var firstValidCalendarDay = GetFirstValidCalendarDay();
+            SendTapped(firstValidCalendarDay);
+            await selectTaskCompletionSource.Task;
+
+            var previousTaskCompletionSource = new TaskCompletionSource<MonthRange>();
+            _calendarView.MonthChanged += previousTaskCompletionSource.SetResult;
+            InvokeCalendarViewMethod("OnPreviousMonthClick", new object[] {null, EventArgs.Empty});
+            await previousTaskCompletionSource.Task;
+            _calendarView.MonthChanged -= previousTaskCompletionSource.SetResult;
+
+            var nextTaskCompletionSource = new TaskCompletionSource<MonthRange>();
+            _calendarView.MonthChanged += nextTaskCompletionSource.SetResult;
+            InvokeCalendarViewMethod("OnNextMonthClick", new object[] {null, EventArgs.Empty});
+            await nextTaskCompletionSource.Task;
+
+            Assert.IsFalse(firstValidCalendarDay.Day!.IsSelected);
+        }
     }
 }

--- a/src/Xalendar.Tests/View/Controls/CalendarViewTests.cs
+++ b/src/Xalendar.Tests/View/Controls/CalendarViewTests.cs
@@ -268,22 +268,22 @@ namespace Xalendar.Tests.View.Controls
         }
 
         [Test]
-        public async Task SelectedDaysShouldBeFirstAndLastDay()
+        public async Task SelectedDaysShouldBeListedInDateOrder()
         {
             _calendarView.SelectMode = SelectMode.Multi;
-            
-            var firstTaskCompletionSource = new TaskCompletionSource<DayTapped>();
-            _calendarView.DayTapped += firstTaskCompletionSource.SetResult;
-            var firstValidCalendarDay = GetFirstValidCalendarDay();
-            SendTapped(firstValidCalendarDay);
-            await firstTaskCompletionSource.Task;
-            _calendarView.DayTapped -= firstTaskCompletionSource.SetResult;
 
             var lastTaskCompletionSource = new TaskCompletionSource<DayTapped>();
             _calendarView.DayTapped += lastTaskCompletionSource.SetResult;
             var lastValidCalendarDay = GetLastValidCalendarDay();
             SendTapped(lastValidCalendarDay);
             await lastTaskCompletionSource.Task;
+            _calendarView.DayTapped -= lastTaskCompletionSource.SetResult;
+
+            var firstTaskCompletionSource = new TaskCompletionSource<DayTapped>();
+            _calendarView.DayTapped += firstTaskCompletionSource.SetResult;
+            var firstValidCalendarDay = GetFirstValidCalendarDay();
+            SendTapped(firstValidCalendarDay);
+            await firstTaskCompletionSource.Task;
 
             Assert.AreEqual(firstValidCalendarDay.Day!.DateTime, _calendarView.SelectedDates.First());
             Assert.AreEqual(lastValidCalendarDay.Day!.DateTime, _calendarView.SelectedDates.Last());

--- a/src/Xalendar/Api/Enums/DayState.cs
+++ b/src/Xalendar/Api/Enums/DayState.cs
@@ -1,0 +1,8 @@
+﻿namespace Xalendar.Api.Enums
+{
+    public enum DayState
+    {
+        Selected,
+        UnSelected
+    }
+}

--- a/src/Xalendar/Api/Enums/SelectMode.cs
+++ b/src/Xalendar/Api/Enums/SelectMode.cs
@@ -1,0 +1,8 @@
+﻿namespace Xalendar.Api.Enums
+{
+    public enum SelectMode
+    {
+        Single,
+        Multi
+    }
+}

--- a/src/Xalendar/Api/Models/Day.cs
+++ b/src/Xalendar/Api/Models/Day.cs
@@ -57,5 +57,10 @@ namespace Xalendar.Api.Models
         public override int GetHashCode() => DateTime.Date.Ticks.GetHashCode();
 
         public override string ToString() => DateTime.Day.ToString();
+
+        public void SwitchSelectedState()
+        {
+            IsSelected = !IsSelected;
+        }
     }
 }

--- a/src/Xalendar/Api/Models/Day.cs
+++ b/src/Xalendar/Api/Models/Day.cs
@@ -62,5 +62,15 @@ namespace Xalendar.Api.Models
         {
             IsSelected = !IsSelected;
         }
+
+        public void UnSelect()
+        {
+            IsSelected = false;
+        }
+
+        public void Select()
+        {
+            IsSelected = true;
+        }
     }
 }

--- a/src/Xalendar/Api/Models/DayTapped.cs
+++ b/src/Xalendar/Api/Models/DayTapped.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using Xalendar.Api.Enums;
+using Xalendar.Api.Interfaces;
+
+namespace Xalendar.Api.Models
+{
+    public struct DayTapped
+    {
+        public DateTime DateTime { get; }
+        public IEnumerable<ICalendarViewEvent> Events { get; }
+        public DayState State { get; }
+
+        public DayTapped(DateTime dateTime, IEnumerable<ICalendarViewEvent> events, DayState state)
+        {
+            DateTime = dateTime;
+            Events = events;
+            State = state;
+        }
+    }
+}

--- a/src/Xalendar/View/Controls/CalendarDay.cs
+++ b/src/Xalendar/View/Controls/CalendarDay.cs
@@ -100,12 +100,16 @@ namespace Xalendar.View.Controls
             return "IsNotPreview";
         }
 
-        internal void UpdateData(Day? day)
+        internal void UpdateData(Day? day, bool shouldSelect)
         {
             Day = day;
             _hasEventsElement.IsVisible = day?.HasEvents ?? false;
             _dayElement.Text = day?.ToString();
-            StartState();
+            
+            if (shouldSelect)
+                Select();
+            else
+                StartState();
         }
 
         public void SwitchSelectedState()

--- a/src/Xalendar/View/Controls/CalendarDay.cs
+++ b/src/Xalendar/View/Controls/CalendarDay.cs
@@ -7,6 +7,7 @@ namespace Xalendar.View.Controls
 {
     internal class CalendarDay : ContentView
     {
+        [Obsolete("Use DayTapped instead of this one")]
         public event Action<CalendarDay?>? DaySelected;
         public event Action<CalendarDay?>? DayTapped;
         internal Day? Day { get; set; }

--- a/src/Xalendar/View/Controls/CalendarDay.cs
+++ b/src/Xalendar/View/Controls/CalendarDay.cs
@@ -8,6 +8,7 @@ namespace Xalendar.View.Controls
     internal class CalendarDay : ContentView
     {
         public event Action<CalendarDay?>? DaySelected;
+        public event Action<CalendarDay?>? DayTapped;
         internal Day? Day { get; set; }
 
         private Label _dayElement;
@@ -44,10 +45,12 @@ namespace Xalendar.View.Controls
 
             var tap = new TapGestureRecognizer();
             tap.Tapped += OnDaySelected;
+            tap.Tapped += OnDayTapped;
             GestureRecognizers.Add(tap);
         }
         
         private void OnDaySelected(object _, EventArgs __) => DaySelected?.Invoke(this);
+        private void OnDayTapped(object _, EventArgs __) => DayTapped?.Invoke(this);
 
         public void Select()
         {

--- a/src/Xalendar/View/Controls/CalendarDay.cs
+++ b/src/Xalendar/View/Controls/CalendarDay.cs
@@ -55,6 +55,7 @@ namespace Xalendar.View.Controls
 
         public void Select()
         {
+            Day?.Select();
             const string state = "Selected";
             VisualStateManager.GoToState(_dayFrame, state);
             VisualStateManager.GoToState(_dayElement, state);
@@ -64,6 +65,7 @@ namespace Xalendar.View.Controls
 
         internal void StartState()
         {
+            Day?.UnSelect();
             VisualStateManager.GoToState(_dayFrame, GetStateOfDayFrame());
             VisualStateManager.GoToState(_dayElement, GetStateOfDayElement());
         }
@@ -108,6 +110,14 @@ namespace Xalendar.View.Controls
             _hasEventsElement.IsVisible = day?.HasEvents ?? false;
             _dayElement.Text = day?.ToString();
             StartState();
+        }
+
+        public void SwitchSelectedState()
+        {
+            if (Day?.IsSelected ?? false)
+                UnSelect();
+            else
+                Select();
         }
     }
 }

--- a/src/Xalendar/View/Controls/CalendarDay.cs
+++ b/src/Xalendar/View/Controls/CalendarDay.cs
@@ -7,8 +7,6 @@ namespace Xalendar.View.Controls
 {
     internal class CalendarDay : ContentView
     {
-        [Obsolete("Use DayTapped instead of this one")]
-        public event Action<CalendarDay?>? DaySelected;
         public event Action<CalendarDay?>? DayTapped;
         internal Day? Day { get; set; }
 
@@ -45,12 +43,10 @@ namespace Xalendar.View.Controls
             Content = _dayFrame;
 
             var tap = new TapGestureRecognizer();
-            tap.Tapped += OnDaySelected;
             tap.Tapped += OnDayTapped;
             GestureRecognizers.Add(tap);
         }
         
-        private void OnDaySelected(object _, EventArgs __) => DaySelected?.Invoke(this);
         private void OnDayTapped(object _, EventArgs __) => DayTapped?.Invoke(this);
 
         public void Select()

--- a/src/Xalendar/View/Controls/CalendarView.xaml.cs
+++ b/src/Xalendar/View/Controls/CalendarView.xaml.cs
@@ -4,6 +4,7 @@ using System.Collections.Specialized;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
+using Xalendar.Api.Enums;
 using Xalendar.Extensions;
 using Xalendar.Api.Interfaces;
 using Xalendar.Api.Models;
@@ -165,6 +166,20 @@ namespace Xalendar.View.Controls
         {
             get => (ResourceDictionary)GetValue(ThemeProperty);
             set => SetValue(ThemeProperty, value);
+        }
+
+        public static BindableProperty SelectModeProperty =
+            BindableProperty.Create(
+                nameof(SelectMode),
+                typeof(SelectMode),
+                typeof(CalendarView),
+                SelectMode.Single,
+                BindingMode.OneTime);
+
+        public SelectMode SelectMode
+        {
+            get => (SelectMode)GetValue(SelectModeProperty);
+            set => SetValue(SelectModeProperty, value);
         }
 
         public event Action<MonthRange>? MonthChanged;

--- a/src/Xalendar/View/Controls/CalendarView.xaml.cs
+++ b/src/Xalendar/View/Controls/CalendarView.xaml.cs
@@ -169,6 +169,7 @@ namespace Xalendar.View.Controls
 
         public event Action<MonthRange>? MonthChanged;
         public event Action<DaySelected>? DaySelected;
+        public event Action<DayTapped>? DayTapped;
 
         private MonthContainer? _monthContainer;
         private int _numberOfDaysInContainer;

--- a/src/Xalendar/View/Controls/CalendarView.xaml.cs
+++ b/src/Xalendar/View/Controls/CalendarView.xaml.cs
@@ -211,7 +211,8 @@ namespace Xalendar.View.Controls
                 foreach (var _ in days)
                 {
                     var calendarDay = new CalendarDay();
-                    calendarDay.DaySelected += CalendarDayOnDaySelected;
+                    // calendarDay.DaySelected += CalendarDayOnDaySelected;
+                    calendarDay.DayTapped += CalendarDayOnDayTapped;
                     CalendarDaysContainer.Children.Add(calendarDay, column, row);
 
                     if (++column > 6)
@@ -250,6 +251,39 @@ namespace Xalendar.View.Controls
             calendarDay.Select();
             _lastSelectedDay = calendarDay;
             DaySelected?.Invoke(new DaySelected(calendarDay.Day.DateTime, calendarDay.Day.Events));
+        }
+        
+        private void CalendarDayOnDayTapped(CalendarDay? calendarDay)
+        {
+            if (calendarDay?.Day is null)
+                return;
+
+            ChangeDayState(calendarDay);
+            var state = calendarDay.Day.IsSelected ? DayState.Selected : DayState.UnSelected;
+            DayTapped?.Invoke(new DayTapped(calendarDay.Day.DateTime, calendarDay.Day.Events, state));
+        }
+
+        private void ChangeDayState(CalendarDay calendarDay)
+        {
+            if (SelectMode == SelectMode.Single)
+                ChangeDayStateForSingleMode(calendarDay);
+
+            if (SelectMode == SelectMode.Multi)
+                ChangeDayStateForMultiMode(calendarDay);
+        }
+
+        private void ChangeDayStateForSingleMode(CalendarDay calendarDay)
+        {
+            if (_lastSelectedDay != calendarDay)
+                _lastSelectedDay?.UnSelect();
+                
+            calendarDay.SwitchSelectedState();
+            _lastSelectedDay = calendarDay;
+        }
+
+        private void ChangeDayStateForMultiMode(CalendarDay calendarDay)
+        {
+            calendarDay.SwitchSelectedState();
         }
 
         private void UnSelectLastSelectedDay()

--- a/src/Xalendar/View/Controls/CalendarView.xaml.cs
+++ b/src/Xalendar/View/Controls/CalendarView.xaml.cs
@@ -246,10 +246,16 @@ namespace Xalendar.View.Controls
             if (calendarDay?.Day is null)
                 return;
             
-            _selectedDay?.UnSelect();
+            UnSelectLastSelectedDay();
             calendarDay.Select();
             _selectedDay = calendarDay;
             DaySelected?.Invoke(new DaySelected(calendarDay.Day.DateTime, calendarDay.Day.Events));
+        }
+
+        private void UnSelectLastSelectedDay()
+        {
+            if (SelectMode == SelectMode.Single)
+                _selectedDay?.UnSelect();
         }
 
         public CalendarView()

--- a/src/Xalendar/View/Controls/CalendarView.xaml.cs
+++ b/src/Xalendar/View/Controls/CalendarView.xaml.cs
@@ -211,7 +211,6 @@ namespace Xalendar.View.Controls
                 foreach (var _ in days)
                 {
                     var calendarDay = new CalendarDay();
-                    // calendarDay.DaySelected += CalendarDayOnDaySelected;
                     calendarDay.DayTapped += CalendarDayOnDayTapped;
                     CalendarDaysContainer.Children.Add(calendarDay, column, row);
 

--- a/src/Xalendar/View/Controls/CalendarView.xaml.cs
+++ b/src/Xalendar/View/Controls/CalendarView.xaml.cs
@@ -168,6 +168,7 @@ namespace Xalendar.View.Controls
         }
 
         public event Action<MonthRange>? MonthChanged;
+        [Obsolete("Use DayTapped instead of this one")]
         public event Action<DaySelected>? DaySelected;
         public event Action<DayTapped>? DayTapped;
 

--- a/src/Xalendar/View/Controls/CalendarView.xaml.cs
+++ b/src/Xalendar/View/Controls/CalendarView.xaml.cs
@@ -395,7 +395,13 @@ namespace Xalendar.View.Controls
                 var day = days[index];
 
                 if (CalendarDaysContainer.Children[index] is CalendarDay view)
-                    view.UpdateData(day);
+                {
+                    var shouldSelect = day is { }
+                                       && SelectMode == SelectMode.Multi
+                                       && _selectedDates.Contains(day.DateTime);
+                    
+                    view.UpdateData(day, shouldSelect);
+                }
             }
         }
     }

--- a/src/Xalendar/View/Controls/CalendarView.xaml.cs
+++ b/src/Xalendar/View/Controls/CalendarView.xaml.cs
@@ -194,7 +194,7 @@ namespace Xalendar.View.Controls
 
         public IReadOnlyList<DateTime> SelectedDates
         {
-            get => _selectedDates;
+            get => _selectedDates.OrderBy(x => x.Date).ToList();
         }
 
         protected override void OnPropertyChanged([CallerMemberName] string? propertyName = null)

--- a/src/Xalendar/View/Controls/CalendarView.xaml.cs
+++ b/src/Xalendar/View/Controls/CalendarView.xaml.cs
@@ -236,11 +236,11 @@ namespace Xalendar.View.Controls
             }
         }
 
-        private CalendarDay? _selectedDay;
+        private CalendarDay? _lastSelectedDay;
 
         private void CalendarDayOnDaySelected(CalendarDay? calendarDay)
         {
-            if (_selectedDay == calendarDay)
+            if (_lastSelectedDay == calendarDay)
                 return;
 
             if (calendarDay?.Day is null)
@@ -248,14 +248,14 @@ namespace Xalendar.View.Controls
             
             UnSelectLastSelectedDay();
             calendarDay.Select();
-            _selectedDay = calendarDay;
+            _lastSelectedDay = calendarDay;
             DaySelected?.Invoke(new DaySelected(calendarDay.Day.DateTime, calendarDay.Day.Events));
         }
 
         private void UnSelectLastSelectedDay()
         {
             if (SelectMode == SelectMode.Single)
-                _selectedDay?.UnSelect();
+                _lastSelectedDay?.UnSelect();
         }
 
         public CalendarView()
@@ -265,8 +265,8 @@ namespace Xalendar.View.Controls
 
         private async void OnPreviousMonthClick(object sender, EventArgs e)
         {
-            _selectedDay?.UnSelect();
-            _selectedDay = null;
+            _lastSelectedDay?.UnSelect();
+            _lastSelectedDay = null;
             
             var result = await Task.Run(() =>
             {
@@ -293,8 +293,8 @@ namespace Xalendar.View.Controls
 
         private async void OnNextMonthClick(object sender, EventArgs e)
         {
-            _selectedDay?.UnSelect();
-            _selectedDay = null;
+            _lastSelectedDay?.UnSelect();
+            _lastSelectedDay = null;
             
             var result = await Task.Run(() =>
             {

--- a/src/Xalendar/View/Controls/CalendarView.xaml.cs
+++ b/src/Xalendar/View/Controls/CalendarView.xaml.cs
@@ -258,10 +258,23 @@ namespace Xalendar.View.Controls
             if (calendarDay?.Day is null)
                 return;
 
-            ChangeDayState(calendarDay);
-            var state = calendarDay.Day.IsSelected ? DayState.Selected : DayState.UnSelected;
-            DayTapped?.Invoke(new DayTapped(calendarDay.Day.DateTime, calendarDay.Day.Events, state));
+            if (IsUsedNewEvent())
+            {
+                ChangeDayState(calendarDay);
+                var state = calendarDay.Day.IsSelected ? DayState.Selected : DayState.UnSelected;
+                DayTapped?.Invoke(new DayTapped(calendarDay.Day.DateTime, calendarDay.Day.Events, state));
+                return;
+            }
+
+            if (IsUsedLegacyEvent())
+            {
+                CalendarDayOnDaySelected(calendarDay);
+                return;
+            }
         }
+
+        private bool IsUsedNewEvent() => DayTapped != null;
+        private bool IsUsedLegacyEvent() => DaySelected != null;
 
         private void ChangeDayState(CalendarDay calendarDay)
         {

--- a/src/Xalendar/View/Controls/CalendarView.xaml.cs
+++ b/src/Xalendar/View/Controls/CalendarView.xaml.cs
@@ -190,6 +190,13 @@ namespace Xalendar.View.Controls
         private MonthContainer? _monthContainer;
         private int _numberOfDaysInContainer;
 
+        private List<DateTime> _selectedDates = new List<DateTime>();
+
+        public IReadOnlyList<DateTime> SelectedDates
+        {
+            get => _selectedDates;
+        }
+
         protected override void OnPropertyChanged([CallerMemberName] string? propertyName = null)
         {
             base.OnPropertyChanged(propertyName);
@@ -261,6 +268,7 @@ namespace Xalendar.View.Controls
             {
                 ChangeDayState(calendarDay);
                 var state = calendarDay.Day.IsSelected ? DayState.Selected : DayState.UnSelected;
+                UpdateSelectedDates(calendarDay.Day.DateTime, state);
                 DayTapped?.Invoke(new DayTapped(calendarDay.Day.DateTime, calendarDay.Day.Events, state));
                 return;
             }
@@ -302,6 +310,21 @@ namespace Xalendar.View.Controls
         {
             if (SelectMode == SelectMode.Single)
                 _lastSelectedDay?.UnSelect();
+        }
+
+        private void UpdateSelectedDates(DateTime dateTime, DayState state)
+        {
+            if (state == DayState.UnSelected)
+            {
+                _selectedDates.Remove(dateTime);
+                return;
+            }
+
+            if (state == DayState.Selected)
+            {
+                _selectedDates.Add(dateTime);
+                return;
+            }
         }
 
         public CalendarView()


### PR DESCRIPTION
This pull request implements a select mode for the calendar view: The `single` and `multi` mode. 

The days can be selected and unselected. Because of this, I deprecated the `DaySelected` event, and I implemented a replacement called `DayTapped`. The `DaySelected` event will be removed in future releases.

There is a new property in the `CalendarView` called `SelectedDates` that returns the selected dates when multi-mode is active.

Usage information can be found in the `Selecting day - multi mode` sample.

| Android | iOS |
| --- | --- |
| <img width="300" src="https://user-images.githubusercontent.com/519642/119279264-f4eb1100-bc00-11eb-9306-026665095cbb.gif" /> | <img width="300" src="https://user-images.githubusercontent.com/519642/119279052-9709f980-bbff-11eb-87f1-7d1d1abf02a5.gif" /> |

Closes https://github.com/ionixjunior/Xalendar/issues/91


