### PR TITLE
Send report to Codecov in develop and main branches

### DIFF
--- a/.github/workflows/publish_package.yml
+++ b/.github/workflows/publish_package.yml
@@ -37,7 +37,11 @@ jobs:
       working-directory: 'src/'
       
     - name: Run unit tests for Xalendar.Tests
-      run: dotnet test src/Xalendar.Tests/Xalendar.Tests.csproj -v n
+      run: dotnet test src/Xalendar.Tests/Xalendar.Tests.csproj -v n /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
+    - name: Send report to codecov.io
+      run: bash <(curl -s https://codecov.io/bash)
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         
   job_3: 
     name: Xalendar release publish

--- a/.github/workflows/publish_package_pre_release.yml
+++ b/.github/workflows/publish_package_pre_release.yml
@@ -37,7 +37,11 @@ jobs:
       working-directory: 'src/'
       
     - name: Run unit tests for Xalendar.Tests
-      run: dotnet test src/Xalendar.Tests/Xalendar.Tests.csproj -v n
+      run: dotnet test src/Xalendar.Tests/Xalendar.Tests.csproj -v n /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
+    - name: Send report to codecov.io
+      run: bash <(curl -s https://codecov.io/bash)
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         
   job_3: 
     name: Xalendar pre-release publish


### PR DESCRIPTION
When we merge the pull requests, we need to generate the coverage report to send to Codecov. This fixes the Codecov Report that appears when a pull request is created.