### PR TITLE
Add support to date interval

### DIFF
--- a/src/Xalendar.Sample/Xalendar.Sample/ViewModels/ChoosingRangeViewModel.cs
+++ b/src/Xalendar.Sample/Xalendar.Sample/ViewModels/ChoosingRangeViewModel.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace Xalendar.Sample.ViewModels
+{
+    public class ChoosingRangeViewModel
+    {
+        public DateTime StartDate { get; private set; }
+        public DateTime EndDate { get; private set; }
+
+        public ChoosingRangeViewModel()
+        {
+            StartDate = DateTime.Today.AddDays(-5);
+            EndDate = DateTime.Today.AddDays(5);
+        }
+    }
+}

--- a/src/Xalendar.Sample/Xalendar.Sample/ViewModels/MainPageViewModel.cs
+++ b/src/Xalendar.Sample/Xalendar.Sample/ViewModels/MainPageViewModel.cs
@@ -18,6 +18,7 @@ namespace Xalendar.Sample.ViewModels
                 new SamplePage { Name = "Selecting day (legacy)", Type = typeof(SelectingDayLegacy) },
                 new SamplePage { Name = "Selecting day - single mode", Type = typeof(SelectingDaySingle) },
                 new SamplePage { Name = "Selecting day - multi mode", Type = typeof(SelectingDayMulti) },
+                new SamplePage { Name = "Choosing range", Type = typeof(ChoosingRange) },
                 new SamplePage { Name = "Choosing theme", Type = typeof(ChoosingTheme) }
             };
         }

--- a/src/Xalendar.Sample/Xalendar.Sample/Views/ChoosingRange.xaml
+++ b/src/Xalendar.Sample/Xalendar.Sample/Views/ChoosingRange.xaml
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<ContentPage
+    x:Class="Xalendar.Sample.Views.ChoosingRange"
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:xal="http://xalendar.com/schemas/xaml">
+    <ContentPage.Content>
+        <xal:CalendarView
+            DayTapped="OnDayTapped"
+            EndDate="{Binding EndDate}"
+            StartDate="{Binding StartDate}" />
+    </ContentPage.Content>
+</ContentPage>

--- a/src/Xalendar.Sample/Xalendar.Sample/Views/ChoosingRange.xaml.cs
+++ b/src/Xalendar.Sample/Xalendar.Sample/Views/ChoosingRange.xaml.cs
@@ -1,0 +1,18 @@
+﻿using Xalendar.Sample.ViewModels;
+using Xamarin.Forms;
+
+namespace Xalendar.Sample.Views
+{
+    public partial class ChoosingRange : ContentPage
+    {
+        public ChoosingRange()
+        {
+            InitializeComponent();
+            BindingContext = new ChoosingRangeViewModel();
+        }
+
+        private void OnDayTapped(Xalendar.Api.Models.DayTapped _)
+        {
+        }
+    }
+}

--- a/src/Xalendar.Tests/Api/Models/DayTests.cs
+++ b/src/Xalendar.Tests/Api/Models/DayTests.cs
@@ -252,5 +252,25 @@ namespace Xalendar.Tests.Api.Models
             
             Assert.IsTrue(day.IsSelected);
         }
+
+        [Test]
+        public void DayShouldBeInRange()
+        {
+            var isInRange = true;
+
+            var day = new Day(DateTime.Now, isInRange: isInRange);
+
+            Assert.IsTrue(day.IsInRange);
+        }
+
+        [Test]
+        public void DayShouldNotBeInRange()
+        {
+            var isInRange = false;
+
+            var day = new Day(DateTime.Now, isInRange: isInRange);
+
+            Assert.IsFalse(day.IsInRange);
+        }
     }
 }

--- a/src/Xalendar.Tests/Api/Models/MonthContainerTests.cs
+++ b/src/Xalendar.Tests/Api/Models/MonthContainerTests.cs
@@ -385,5 +385,269 @@ namespace Xalendar.Tests.Api.Models
                     .ToUpper();
             }
         }
+
+        [Test]
+        public void DayOfCurrentMonthShouldBeInRange()
+        {
+            var dateTime = new DateTime(2021, 11, 1);
+            var targetDateTime = new DateTime(2021, 11, 10);
+            var startDate = targetDateTime.AddDays(-5);
+            var endDate = targetDateTime.AddDays(5);
+
+            var monthContaier = new MonthContainer(dateTime, firstDayOfWeek: DayOfWeek.Sunday, startDate: startDate, endDate: endDate, isPreviewDaysActive: true);
+
+            var targetDay = monthContaier.Days.First(x => x.DateTime.Date == targetDateTime.Date);
+            Assert.IsTrue(targetDay.IsInRange);
+        }
+
+        [Test]
+        public void DayOfCurrentMonthShouldNotBeInRange()
+        {
+            var dateTime = new DateTime(2021, 11, 1);
+            var targetDateTime = new DateTime(2021, 11, 10);
+            var startDate = targetDateTime.AddDays(5);
+            var endDate = targetDateTime.AddDays(10);
+
+            var monthContaier = new MonthContainer(dateTime, firstDayOfWeek: DayOfWeek.Sunday, startDate: startDate, endDate: endDate, isPreviewDaysActive: true);
+
+            var targetDay = monthContaier.Days.First(x => x.DateTime.Date == targetDateTime.Date);
+            Assert.IsFalse(targetDay.IsInRange);
+        }
+
+        [Test]
+        public void PreviousMonthDayShouldBeInRange()
+        {
+            var dateTime = new DateTime(2021, 11, 1);
+            var targetDateTime = new DateTime(2021, 10, 31);
+            var startDate = targetDateTime.AddDays(-5);
+            var endDate = targetDateTime.AddDays(5);
+
+            var monthContaier = new MonthContainer(dateTime, firstDayOfWeek: DayOfWeek.Sunday, startDate: startDate, endDate: endDate, isPreviewDaysActive: true);
+
+            var targetDay = monthContaier.Days.First(x => x.DateTime.Date == targetDateTime.Date);
+            Assert.IsTrue(targetDay.IsInRange);
+        }
+
+        [Test]
+        public void PreviousMonthDayShouldNotBeInRange()
+        {
+            var dateTime = new DateTime(2021, 11, 1);
+            var targetDateTime = new DateTime(2021, 10, 31);
+            var startDate = targetDateTime.AddDays(5);
+            var endDate = targetDateTime.AddDays(10);
+
+            var monthContaier = new MonthContainer(dateTime, firstDayOfWeek: DayOfWeek.Sunday, startDate: startDate, endDate: endDate, isPreviewDaysActive: true);
+
+            var targetDay = monthContaier.Days.First(x => x.DateTime.Date == targetDateTime.Date);
+            Assert.IsFalse(targetDay.IsInRange);
+        }
+
+        [Test]
+        public void NextMonthDayShouldBeInRange()
+        {
+            var dateTime = new DateTime(2021, 11, 1);
+            var targetDateTime = new DateTime(2021, 12, 1);
+            var startDate = targetDateTime.AddDays(-5);
+            var endDate = targetDateTime.AddDays(5);
+
+            var monthContaier = new MonthContainer(dateTime, firstDayOfWeek: DayOfWeek.Sunday, startDate: startDate, endDate: endDate, isPreviewDaysActive: true);
+
+            var targetDay = monthContaier.Days.First(x => x.DateTime.Date == targetDateTime.Date);
+            Assert.IsTrue(targetDay.IsInRange);
+        }
+
+        [Test]
+        public void NextMonthDayShouldNotBeInRange()
+        {
+            var dateTime = new DateTime(2021, 11, 1);
+            var targetDateTime = new DateTime(2021, 12, 1);
+            var startDate = targetDateTime.AddDays(5);
+            var endDate = targetDateTime.AddDays(10);
+
+            var monthContaier = new MonthContainer(dateTime, firstDayOfWeek: DayOfWeek.Sunday, startDate: startDate, endDate: endDate, isPreviewDaysActive: true);
+
+            var targetDay = monthContaier.Days.First(x => x.DateTime.Date == targetDateTime.Date);
+            Assert.IsFalse(targetDay.IsInRange);
+        }
+
+        [Test]
+        public void DayOfCurrentMonthShouldBeInRangeWhenNavigateToPreviousMonth()
+        {
+            var dateTime = new DateTime(2021, 11, 1);
+            var targetDateTime = new DateTime(2021, 10, 10);
+            var startDate = targetDateTime.AddDays(-5);
+            var endDate = targetDateTime.AddDays(5);
+
+            var monthContaier = new MonthContainer(dateTime, firstDayOfWeek: DayOfWeek.Sunday, startDate: startDate, endDate: endDate, isPreviewDaysActive: true);
+            monthContaier.Previous();
+
+            var targetDay = monthContaier.Days.First(x => x.DateTime.Date == targetDateTime.Date);
+            Assert.IsTrue(targetDay.IsInRange);
+        }
+
+        [Test]
+        public void DayOfCurrentMonthShouldNotBeInRangeWhenNavigateToPreviousMonth()
+        {
+            var dateTime = new DateTime(2021, 11, 1);
+            var targetDateTime = new DateTime(2021, 10, 10);
+            var startDate = targetDateTime.AddDays(5);
+            var endDate = targetDateTime.AddDays(10);
+
+            var monthContaier = new MonthContainer(dateTime, firstDayOfWeek: DayOfWeek.Sunday, startDate: startDate, endDate: endDate, isPreviewDaysActive: true);
+            monthContaier.Previous();
+
+            var targetDay = monthContaier.Days.First(x => x.DateTime.Date == targetDateTime.Date);
+            Assert.IsFalse(targetDay.IsInRange);
+        }
+
+        [Test]
+        public void PreviousMonthDayShouldBeInRangeWhenNavigateToPreviousMonth()
+        {
+            var dateTime = new DateTime(2021, 11, 1);
+            var targetDateTime = new DateTime(2021, 9, 30);
+            var startDate = targetDateTime.AddDays(-5);
+            var endDate = targetDateTime.AddDays(5);
+
+            var monthContaier = new MonthContainer(dateTime, firstDayOfWeek: DayOfWeek.Sunday, startDate: startDate, endDate: endDate, isPreviewDaysActive: true);
+            monthContaier.Previous();
+
+            var targetDay = monthContaier.Days.First(x => x.DateTime.Date == targetDateTime.Date);
+            Assert.IsTrue(targetDay.IsInRange);
+        }
+
+        [Test]
+        public void PreviousMonthDayShouldNotBeInRangeWhenNavigateToPreviousMonth()
+        {
+            var dateTime = new DateTime(2021, 11, 1);
+            var targetDateTime = new DateTime(2021, 9, 30);
+            var startDate = targetDateTime.AddDays(5);
+            var endDate = targetDateTime.AddDays(10);
+
+            var monthContaier = new MonthContainer(dateTime, firstDayOfWeek: DayOfWeek.Sunday, startDate: startDate, endDate: endDate, isPreviewDaysActive: true);
+            monthContaier.Previous();
+
+            var targetDay = monthContaier.Days.First(x => x.DateTime.Date == targetDateTime.Date);
+            Assert.IsFalse(targetDay.IsInRange);
+        }
+
+        [Test]
+        public void NextMonthDayShouldBeInRangeWhenNavigateToPreviousMonth()
+        {
+            var dateTime = new DateTime(2021, 11, 1);
+            var targetDateTime = new DateTime(2021, 11, 1);
+            var startDate = targetDateTime.AddDays(-5);
+            var endDate = targetDateTime.AddDays(5);
+
+            var monthContaier = new MonthContainer(dateTime, firstDayOfWeek: DayOfWeek.Sunday, startDate: startDate, endDate: endDate, isPreviewDaysActive: true);
+            monthContaier.Previous();
+
+            var targetDay = monthContaier.Days.First(x => x.DateTime.Date == targetDateTime.Date);
+            Assert.IsTrue(targetDay.IsInRange);
+        }
+
+        [Test]
+        public void NextMonthDayShouldNotBeInRangeWhenNavigateToPreviousMonth()
+        {
+            var dateTime = new DateTime(2021, 11, 1);
+            var targetDateTime = new DateTime(2021, 11, 1);
+            var startDate = targetDateTime.AddDays(5);
+            var endDate = targetDateTime.AddDays(10);
+
+            var monthContaier = new MonthContainer(dateTime, firstDayOfWeek: DayOfWeek.Sunday, startDate: startDate, endDate: endDate, isPreviewDaysActive: true);
+            monthContaier.Previous();
+
+            var targetDay = monthContaier.Days.First(x => x.DateTime.Date == targetDateTime.Date);
+            Assert.IsFalse(targetDay.IsInRange);
+        }
+
+        [Test]
+        public void DayOfCurrentMonthShouldBeInRangeWhenNavigateToNextMonth()
+        {
+            var dateTime = new DateTime(2021, 11, 1);
+            var targetDateTime = new DateTime(2021, 12, 10);
+            var startDate = targetDateTime.AddDays(-5);
+            var endDate = targetDateTime.AddDays(5);
+
+            var monthContaier = new MonthContainer(dateTime, firstDayOfWeek: DayOfWeek.Sunday, startDate: startDate, endDate: endDate, isPreviewDaysActive: true);
+            monthContaier.Next();
+
+            var targetDay = monthContaier.Days.First(x => x.DateTime.Date == targetDateTime.Date);
+            Assert.IsTrue(targetDay.IsInRange);
+        }
+
+        [Test]
+        public void DayOfCurrentMonthShouldNotBeInRangeWhenNavigateToNextMonth()
+        {
+            var dateTime = new DateTime(2021, 11, 1);
+            var targetDateTime = new DateTime(2021, 12, 10);
+            var startDate = targetDateTime.AddDays(5);
+            var endDate = targetDateTime.AddDays(10);
+
+            var monthContaier = new MonthContainer(dateTime, firstDayOfWeek: DayOfWeek.Sunday, startDate: startDate, endDate: endDate, isPreviewDaysActive: true);
+            monthContaier.Next();
+
+            var targetDay = monthContaier.Days.First(x => x.DateTime.Date == targetDateTime.Date);
+            Assert.IsFalse(targetDay.IsInRange);
+        }
+
+        [Test]
+        public void PreviousMonthDayShouldBeInRangeWhenNavigateToNextMonth()
+        {
+            var dateTime = new DateTime(2021, 11, 1);
+            var targetDateTime = new DateTime(2021, 11, 30);
+            var startDate = targetDateTime.AddDays(-5);
+            var endDate = targetDateTime.AddDays(5);
+
+            var monthContaier = new MonthContainer(dateTime, firstDayOfWeek: DayOfWeek.Sunday, startDate: startDate, endDate: endDate, isPreviewDaysActive: true);
+            monthContaier.Next();
+
+            var targetDay = monthContaier.Days.First(x => x.DateTime.Date == targetDateTime.Date);
+            Assert.IsTrue(targetDay.IsInRange);
+        }
+
+        [Test]
+        public void PreviousMonthDayShouldNotBeInRangeWhenNavigateToNextMonth()
+        {
+            var dateTime = new DateTime(2021, 11, 1);
+            var targetDateTime = new DateTime(2021, 11, 30);
+            var startDate = targetDateTime.AddDays(5);
+            var endDate = targetDateTime.AddDays(10);
+
+            var monthContaier = new MonthContainer(dateTime, firstDayOfWeek: DayOfWeek.Sunday, startDate: startDate, endDate: endDate, isPreviewDaysActive: true);
+            monthContaier.Next();
+
+            var targetDay = monthContaier.Days.First(x => x.DateTime.Date == targetDateTime.Date);
+            Assert.IsFalse(targetDay.IsInRange);
+        }
+
+        [Test]
+        public void NextMonthDayShouldBeInRangeWhenNavigateToNextMonth()
+        {
+            var dateTime = new DateTime(2021, 11, 1);
+            var targetDateTime = new DateTime(2022, 1, 1);
+            var startDate = targetDateTime.AddDays(-5);
+            var endDate = targetDateTime.AddDays(5);
+
+            var monthContaier = new MonthContainer(dateTime, firstDayOfWeek: DayOfWeek.Sunday, startDate: startDate, endDate: endDate, isPreviewDaysActive: true);
+            monthContaier.Next();
+
+            var targetDay = monthContaier.Days.First(x => x.DateTime.Date == targetDateTime.Date);
+            Assert.IsTrue(targetDay.IsInRange);
+        }
+
+        [Test]
+        public void NextMonthDayShouldNotBeInRangeWhenNavigateToNextMonth()
+        {
+            var dateTime = new DateTime(2021, 11, 1);
+            var targetDateTime = new DateTime(2022, 1, 1);
+            var startDate = targetDateTime.AddDays(5);
+            var endDate = targetDateTime.AddDays(10);
+
+            var monthContaier = new MonthContainer(dateTime, firstDayOfWeek: DayOfWeek.Sunday, startDate: startDate, endDate: endDate, isPreviewDaysActive: true);
+            monthContaier.Next();
+
+            var targetDay = monthContaier.Days.First(x => x.DateTime.Date == targetDateTime.Date);
+            Assert.IsFalse(targetDay.IsInRange);
+        }
     }
 }

--- a/src/Xalendar.Tests/Api/Models/MonthTests.cs
+++ b/src/Xalendar.Tests/Api/Models/MonthTests.cs
@@ -286,5 +286,33 @@ namespace Xalendar.Tests.Api.Models
             var eventsOfMonth = month.Days.Where(day => day.Events.Any());
             Assert.IsEmpty(eventsOfMonth);
         }
+
+        [Test]
+        public void DayShouldBeInRange()
+        {
+            var dateTime = new DateTime(2021, 11, 1);
+            var targetDateTime = new DateTime(2021, 11, 10);
+            var startDate = targetDateTime.AddDays(-5);
+            var endDate = targetDateTime.AddDays(5);
+
+            var month = new Month(dateTime, startDate: startDate, endDate: endDate);
+
+            var targetDay = month.Days.Where(x => x.DateTime.Date == targetDateTime.Date).First();
+            Assert.IsTrue(targetDay.IsInRange);
+        }
+
+        [Test]
+        public void DayShouldNotBeInRange()
+        {
+            var dateTime = new DateTime(2021, 11, 1);
+            var targetDateTime = new DateTime(2021, 11, 10);
+            var startDate = targetDateTime.AddDays(5);
+            var endDate = targetDateTime.AddDays(10);
+
+            var month = new Month(dateTime, startDate: startDate, endDate: endDate);
+
+            var targetDay = month.Days.Where(x => x.DateTime.Date == targetDateTime.Date).First();
+            Assert.IsFalse(targetDay.IsInRange);
+        }
     }
 }

--- a/src/Xalendar/Api/Models/Day.cs
+++ b/src/Xalendar/Api/Models/Day.cs
@@ -21,16 +21,17 @@ namespace Xalendar.Api.Models
         
         public bool HasEvents => Events.Any();
 
-        public Day(DateTime dateTime, bool isSelected = false, bool isCurrentMonth = true) : this(dateTime, DateTime.Now, isSelected, isCurrentMonth)
+        public Day(DateTime dateTime, bool isSelected = false, bool isCurrentMonth = true, bool isInRange = true) : this(dateTime, DateTime.Now, isSelected, isCurrentMonth, isInRange)
         {
         }
 
-        public Day(DateTime dateTime, DateTime currentDateTime, bool isSelected = false, bool isCurrentMonth = true)
+        public Day(DateTime dateTime, DateTime currentDateTime, bool isSelected = false, bool isCurrentMonth = true, bool isInRange = true)
         {
             _currentDateTime = currentDateTime;
             _isCurrentMonth = isCurrentMonth;
             DateTime = dateTime;
             _isSelected = isSelected;
+            IsInRange = isInRange;
             Events = new List<ICalendarViewEvent>();
         }
 
@@ -45,6 +46,8 @@ namespace Xalendar.Api.Models
         }
 
         public bool IsPreview => !_isCurrentMonth;
+
+        public bool IsInRange { get; private set; }
 
         public override bool Equals(object obj)
         {

--- a/src/Xalendar/Api/Models/Month.cs
+++ b/src/Xalendar/Api/Models/Month.cs
@@ -10,10 +10,10 @@ namespace Xalendar.Api.Models
         public DateTime MonthDateTime { get; }
         public IReadOnlyList<Day> Days { get; }
 
-        public Month(DateTime dateTime, bool isCurrentMonth = true)
+        public Month(DateTime dateTime, DateTime? startDate = null, DateTime? endDate = null, bool isCurrentMonth = true)
         {
             MonthDateTime = dateTime;
-            Days = GenerateDaysOfMonth(dateTime, isCurrentMonth);
+            Days = GenerateDaysOfMonth(dateTime, startDate, endDate, isCurrentMonth);
         }
 
         public bool Equals(Month other)

--- a/src/Xalendar/Api/Models/MonthContainer.cs
+++ b/src/Xalendar/Api/Models/MonthContainer.cs
@@ -23,21 +23,25 @@ namespace Xalendar.Api.Models
         private DayOfWeek _firstDayOfWeek;
         private bool _isPreviewDaysActive;
         private IDayOfWeekFormatter _dayOfWeekFormatter;
+        private DateTime? _startDate;
+        private DateTime? _endDate;
 
-        public MonthContainer(DateTime dateTime, DayOfWeek firstDayOfWeek = DayOfWeek.Sunday,
-            bool isPreviewDaysActive = false) : this(dateTime, new DayOfWeek3CaractersFormat(), firstDayOfWeek, isPreviewDaysActive)
+        public MonthContainer(DateTime dateTime, DayOfWeek firstDayOfWeek = DayOfWeek.Sunday, DateTime? startDate = null, DateTime? endDate = null, 
+            bool isPreviewDaysActive = false) : this(dateTime, new DayOfWeek3CaractersFormat(), startDate, endDate, firstDayOfWeek, isPreviewDaysActive)
         {
         }
 
-        public MonthContainer(DateTime dateTime, IDayOfWeekFormatter dayOfWeekFormatter, DayOfWeek firstDayOfWeek = DayOfWeek.Sunday,
+        public MonthContainer(DateTime dateTime, IDayOfWeekFormatter dayOfWeekFormatter, DateTime? startDate = null, DateTime? endDate = null, DayOfWeek firstDayOfWeek = DayOfWeek.Sunday,
             bool isPreviewDaysActive = false)
         {
-            _currentMonth = new Month(dateTime);
+            _startDate = startDate;
+            _endDate = endDate;
+            _currentMonth = new Month(dateTime, startDate: _startDate, endDate: _endDate);
 
             if (isPreviewDaysActive)
             {
-                _previousMonth = new Month(dateTime.AddMonths(-1), isCurrentMonth: false);
-                _nextMonth = new Month(dateTime.AddMonths(1), isCurrentMonth: false);
+                _previousMonth = new Month(dateTime.AddMonths(-1), startDate: _startDate, endDate: _endDate, isCurrentMonth: false);
+                _nextMonth = new Month(dateTime.AddMonths(1), startDate: _startDate, endDate: _endDate, isCurrentMonth: false);
             }
 
             _dayOfWeekFormatter = dayOfWeekFormatter;
@@ -155,26 +159,26 @@ namespace Xalendar.Api.Models
         public void Next()
         {
             var nextDateTime = _currentMonth.MonthDateTime.AddMonths(1);
-            _currentMonth = new Month(nextDateTime);
+            _currentMonth = new Month(nextDateTime, startDate: _startDate, endDate: _endDate);
             _days = null;
 
             if (_isPreviewDaysActive)
             {
-                _previousMonth = new Month(nextDateTime.AddMonths(-1), isCurrentMonth: false);
-                _nextMonth = new Month(nextDateTime.AddMonths(1), isCurrentMonth: false);
+                _previousMonth = new Month(nextDateTime.AddMonths(-1), startDate: _startDate, endDate: _endDate, isCurrentMonth: false);
+                _nextMonth = new Month(nextDateTime.AddMonths(1), startDate: _startDate, endDate: _endDate, isCurrentMonth: false);
             }
         }
 
         public void Previous()
         {
             var previousDateTime = _currentMonth.MonthDateTime.AddMonths(-1);
-            _currentMonth = new Month(previousDateTime);
+            _currentMonth = new Month(previousDateTime, startDate: _startDate, endDate: _endDate);
             _days = null;
 
             if (_isPreviewDaysActive)
             {
-                _previousMonth = new Month(previousDateTime.AddMonths(-1), isCurrentMonth: false);
-                _nextMonth = new Month(previousDateTime.AddMonths(1), isCurrentMonth: false);
+                _previousMonth = new Month(previousDateTime.AddMonths(-1), startDate: _startDate, endDate: _endDate, isCurrentMonth: false);
+                _nextMonth = new Month(previousDateTime.AddMonths(1), startDate: _startDate, endDate: _endDate, isCurrentMonth: false);
             }
         }
     }

--- a/src/Xalendar/Extensions/MonthExtension.cs
+++ b/src/Xalendar/Extensions/MonthExtension.cs
@@ -45,14 +45,18 @@ namespace Xalendar.Extensions
                 .Select(dayValue => new DateTime(dateTime.Year, dateTime.Month, dayValue))
                 .Select(dateTime =>
                 {
-                    bool isInRange = true;
-
-                    if (startDate.HasValue && endDate.HasValue)
-                        isInRange = dateTime.Date >= startDate.Value.Date && dateTime.Date <= endDate.Value.Date ? true : false;
-
+                    var isInRange = CheckIfDateTimeIsInRange(dateTime, startDate, endDate);
                     return new Day(dateTime, isCurrentMonth: isCurrentMonth, isInRange: isInRange);
                 })
                 .ToList();
+        }
+
+        private static bool CheckIfDateTimeIsInRange(DateTime dateTime, DateTime? startDate, DateTime? endDate)
+        {
+            if (startDate.HasValue && endDate.HasValue)
+                return dateTime.Date >= startDate.Value.Date && dateTime.Date <= endDate.Value.Date ? true : false;
+
+            return true;
         }
 
         public static void AddEvents(this Month month, IEnumerable<ICalendarViewEvent> events)

--- a/src/Xalendar/Extensions/MonthExtension.cs
+++ b/src/Xalendar/Extensions/MonthExtension.cs
@@ -38,12 +38,20 @@ namespace Xalendar.Extensions
             return month.Days.FirstOrDefault(day => day.IsSelected);
         }
         
-        public static List<Day> GenerateDaysOfMonth(DateTime dateTime, bool isCurrentMonth = true)
+        public static List<Day> GenerateDaysOfMonth(DateTime dateTime, DateTime? startDate, DateTime? endDate, bool isCurrentMonth = true)
         {
             return Enumerable
                 .Range(1, DateTime.DaysInMonth(dateTime.Year, dateTime.Month))
                 .Select(dayValue => new DateTime(dateTime.Year, dateTime.Month, dayValue))
-                .Select(dateTime => new Day(dateTime, isCurrentMonth: isCurrentMonth))
+                .Select(dateTime =>
+                {
+                    bool isInRange = true;
+
+                    if (startDate.HasValue && endDate.HasValue)
+                        isInRange = dateTime.Date >= startDate.Value.Date && dateTime.Date <= endDate.Value.Date ? true : false;
+
+                    return new Day(dateTime, isCurrentMonth: isCurrentMonth, isInRange: isInRange);
+                })
                 .ToList();
         }
 

--- a/src/Xalendar/View/Controls/CalendarDay.cs
+++ b/src/Xalendar/View/Controls/CalendarDay.cs
@@ -94,6 +94,9 @@ namespace Xalendar.View.Controls
                 if (Day.IsPreview)
                     return "IsPreview";
 
+                if (Day.IsInRange == false)
+                    return "IsNotInRange";
+
                 if (Day.IsWeekend)
                     return "IsWeekend";
 

--- a/src/Xalendar/View/Controls/CalendarDay.cs
+++ b/src/Xalendar/View/Controls/CalendarDay.cs
@@ -46,8 +46,12 @@ namespace Xalendar.View.Controls
             tap.Tapped += OnDayTapped;
             GestureRecognizers.Add(tap);
         }
-        
-        private void OnDayTapped(object _, EventArgs __) => DayTapped?.Invoke(this);
+
+        private void OnDayTapped(object _, EventArgs __)
+        {
+            if (Day is { IsInRange: true })
+                DayTapped?.Invoke(this);
+        }
 
         public void Select()
         {

--- a/src/Xalendar/View/Controls/CalendarView.xaml.cs
+++ b/src/Xalendar/View/Controls/CalendarView.xaml.cs
@@ -9,7 +9,6 @@ using Xalendar.Extensions;
 using Xalendar.Api.Interfaces;
 using Xalendar.Api.Models;
 using Xamarin.Forms;
-using XView = Xamarin.Forms.View;
 using Xalendar.Api.Formatters;
 using Xalendar.View.Themes;
 

--- a/src/Xalendar/View/Controls/CalendarView.xaml.cs
+++ b/src/Xalendar/View/Controls/CalendarView.xaml.cs
@@ -204,7 +204,7 @@ namespace Xalendar.View.Controls
             if (propertyName == "Renderer")
             {
                 Resources.MergedDictionaries.Add(Theme);
-                _monthContainer = new MonthContainer(DateTime.Today, DaysOfWeekFormatter, FirstDayOfWeek, IsPreviewDaysActive);
+                _monthContainer = new MonthContainer(DateTime.Today, dayOfWeekFormatter: DaysOfWeekFormatter, firstDayOfWeek: FirstDayOfWeek, isPreviewDaysActive: IsPreviewDaysActive);
                 
                 if (!Events.IsNullOrEmpty())
                     _monthContainer.AddEvents(Events);

--- a/src/Xalendar/View/Controls/CalendarView.xaml.cs
+++ b/src/Xalendar/View/Controls/CalendarView.xaml.cs
@@ -182,6 +182,34 @@ namespace Xalendar.View.Controls
             set => SetValue(SelectModeProperty, value);
         }
 
+        public static BindableProperty StartDateProperty =
+            BindableProperty.Create(
+                nameof(StartDate),
+                typeof(DateTime?),
+                typeof(CalendarView),
+                null,
+                BindingMode.OneTime);
+
+        public DateTime? StartDate
+        {
+            get => (DateTime?)GetValue(StartDateProperty);
+            set => SetValue(StartDateProperty, value);
+        }
+
+        public static BindableProperty EndDateProperty =
+            BindableProperty.Create(
+                nameof(EndDate),
+                typeof(DateTime?),
+                typeof(CalendarView),
+                null,
+                BindingMode.OneTime);
+
+        public DateTime? EndDate
+        {
+            get => (DateTime?)GetValue(EndDateProperty);
+            set => SetValue(EndDateProperty, value);
+        }
+
         public event Action<MonthRange>? MonthChanged;
         [Obsolete("Use DayTapped instead of this one")]
         public event Action<DaySelected>? DaySelected;
@@ -204,7 +232,13 @@ namespace Xalendar.View.Controls
             if (propertyName == "Renderer")
             {
                 Resources.MergedDictionaries.Add(Theme);
-                _monthContainer = new MonthContainer(DateTime.Today, dayOfWeekFormatter: DaysOfWeekFormatter, firstDayOfWeek: FirstDayOfWeek, isPreviewDaysActive: IsPreviewDaysActive);
+                _monthContainer = new MonthContainer(
+                    DateTime.Today,
+                    dayOfWeekFormatter: DaysOfWeekFormatter,
+                    startDate: StartDate,
+                    endDate: EndDate,
+                    firstDayOfWeek: FirstDayOfWeek,
+                    isPreviewDaysActive: IsPreviewDaysActive);
                 
                 if (!Events.IsNullOrEmpty())
                     _monthContainer.AddEvents(Events);

--- a/src/Xalendar/View/Themes/Amazonas.xaml
+++ b/src/Xalendar/View/Themes/Amazonas.xaml
@@ -163,6 +163,12 @@
                             <Setter Property="TextColor" Value="White" />
                         </VisualState.Setters>
                     </VisualState>
+
+                    <VisualState x:Name="IsNotInRange">
+                        <VisualState.Setters>
+                            <Setter Property="TextColor" Value="#cccccc" />
+                        </VisualState.Setters>
+                    </VisualState>
                 </VisualStateGroup>
             </VisualStateGroupList>
         </Setter>

--- a/src/Xalendar/View/Themes/Classic.xaml
+++ b/src/Xalendar/View/Themes/Classic.xaml
@@ -161,6 +161,12 @@
                             <Setter Property="TextColor" Value="Black" />
                         </VisualState.Setters>
                     </VisualState>
+
+                    <VisualState x:Name="IsNotInRange">
+                        <VisualState.Setters>
+                            <Setter Property="TextColor" Value="#cccccc" />
+                        </VisualState.Setters>
+                    </VisualState>
                 </VisualStateGroup>
             </VisualStateGroupList>
         </Setter>

--- a/src/Xalendar/View/Themes/Planning.xaml
+++ b/src/Xalendar/View/Themes/Planning.xaml
@@ -171,6 +171,12 @@
                             <Setter Property="TextColor" Value="Black" />
                         </VisualState.Setters>
                     </VisualState>
+
+                    <VisualState x:Name="IsNotInRange">
+                        <VisualState.Setters>
+                            <Setter Property="TextColor" Value="#cccccc" />
+                        </VisualState.Setters>
+                    </VisualState>
                 </VisualStateGroup>
             </VisualStateGroupList>
         </Setter>

--- a/src/Xalendar/View/Themes/TaskManagement.xaml
+++ b/src/Xalendar/View/Themes/TaskManagement.xaml
@@ -194,6 +194,12 @@
                             <Setter Property="TextColor" Value="White" />
                         </VisualState.Setters>
                     </VisualState>
+
+                    <VisualState x:Name="IsNotInRange">
+                        <VisualState.Setters>
+                            <Setter Property="TextColor" Value="#cccccc" />
+                        </VisualState.Setters>
+                    </VisualState>
                 </VisualStateGroup>
             </VisualStateGroupList>
         </Setter>


### PR DESCRIPTION
When we start the calendar, we need to specify two new properties to customize it: StartDate and EndDate. These properties control if a selected day can invoke the DayTapped event. A new style for days outside of the range was added to render correctly the day in the calendar.

At this moment, these bindable properties are configured with one-time binding. The days outside of the range appears in a gray scale color.

![image](https://user-images.githubusercontent.com/519642/143689303-af27608f-5735-49ef-95a9-ec2eef1ebf36.png)

Closes https://github.com/ionixjunior/Xalendar/issues/101
